### PR TITLE
Actually register inhibit cookies

### DIFF
--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -373,6 +373,7 @@ void handleDbusScreensaver(sdbus::MethodCall call, bool inhibit) {
     } else {
         uint32_t cookie = 0;
         call >> cookie;
+        Debug::log(TRACE, "Read uninhibit cookie: {}", cookie);
         const auto COOKIE = g_pHypridle->getDbusInhibitCookie(cookie);
         if (COOKIE.cookie == 0) {
             Debug::log(WARN, "No cookie in uninhibit");
@@ -396,11 +397,15 @@ void handleDbusScreensaver(sdbus::MethodCall call, bool inhibit) {
     static int cookieID = 1337;
 
     if (inhibit) {
+        auto cookie = CHypridle::SDbusInhibitCookie{uint32_t{cookieID}, app, reason};
+
         auto reply = call.createReply();
         reply << uint32_t{cookieID++};
         reply.send();
 
         Debug::log(LOG, "Cookie {} sent", cookieID - 1);
+
+        g_pHypridle->registerDbusInhibitCookie(cookie);
     } else {
         auto reply = call.createReply();
         reply.send();

--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -316,6 +316,17 @@ void CHypridle::registerDbusInhibitCookie(CHypridle::SDbusInhibitCookie& cookie)
     m_sDBUSState.inhibitCookies.push_back(cookie);
 }
 
+void CHypridle::unregisterDbusInhibitCookie(const CHypridle::SDbusInhibitCookie& cookie) {
+    auto it = std::find_if(m_sDBUSState.inhibitCookies.begin(), m_sDBUSState.inhibitCookies.end(),
+                           [&cookie](const CHypridle::SDbusInhibitCookie& item) { return item.cookie == cookie.cookie; });
+
+    if (it == m_sDBUSState.inhibitCookies.end()) {
+        Debug::log(WARN, "BUG THIS: attempted to unregister unknown cookie");
+    } else {
+        m_sDBUSState.inhibitCookies.erase(it);
+    }
+}
+
 void handleDbusLogin(sdbus::Message& msg) {
     // lock & unlock
     static auto* const PLOCKCMD   = (Hyprlang::STRING const*)g_pConfigManager->getValuePtr("general:lock_cmd");
@@ -380,6 +391,7 @@ void handleDbusScreensaver(sdbus::MethodCall call, bool inhibit) {
         } else {
             app    = COOKIE.app;
             reason = COOKIE.reason;
+            g_pHypridle->unregisterDbusInhibitCookie(COOKIE);
         }
     }
 

--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -317,14 +317,13 @@ void CHypridle::registerDbusInhibitCookie(CHypridle::SDbusInhibitCookie& cookie)
 }
 
 void CHypridle::unregisterDbusInhibitCookie(const CHypridle::SDbusInhibitCookie& cookie) {
-    auto it = std::find_if(m_sDBUSState.inhibitCookies.begin(), m_sDBUSState.inhibitCookies.end(),
-                           [&cookie](const CHypridle::SDbusInhibitCookie& item) { return item.cookie == cookie.cookie; });
+    const auto IT = std::find_if(m_sDBUSState.inhibitCookies.begin(), m_sDBUSState.inhibitCookies.end(),
+                                 [&cookie](const CHypridle::SDbusInhibitCookie& item) { return item.cookie == cookie.cookie; });
 
-    if (it == m_sDBUSState.inhibitCookies.end()) {
+    if (IT == m_sDBUSState.inhibitCookies.end())
         Debug::log(WARN, "BUG THIS: attempted to unregister unknown cookie");
-    } else {
-        m_sDBUSState.inhibitCookies.erase(it);
-    }
+    else
+        m_sDBUSState.inhibitCookies.erase(IT);
 }
 
 void handleDbusLogin(sdbus::Message& msg) {

--- a/src/core/Hypridle.hpp
+++ b/src/core/Hypridle.hpp
@@ -34,6 +34,7 @@ class CHypridle {
 
     SDbusInhibitCookie getDbusInhibitCookie(uint32_t cookie);
     void               registerDbusInhibitCookie(SDbusInhibitCookie& cookie);
+    void               unregisterDbusInhibitCookie(const SDbusInhibitCookie& cookie);
 
   private:
     void    setupDBUS();


### PR DESCRIPTION
I'm not sure if this was intentional or not, but when going over the code of hypridle, I noticed that the inhibit cookies that are created and sending back to dbus aren't actually getting registered, so uninhibit never detects a valid cookie.

Unless this was done intentionally, because the support isn't yet ready or whatever, these cookies should really be getting registered once created.