### PR TITLE
Gracefully exit without (e)logind

### DIFF
--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -430,10 +430,15 @@ void CHypridle::setupDBUS() {
     auto proxy  = sdbus::createProxy("org.freedesktop.login1", "/org/freedesktop/login1");
     auto method = proxy->createMethodCall("org.freedesktop.login1.Manager", "GetSession");
     method << "auto";
-    auto              reply = proxy->callMethod(method);
-
     sdbus::ObjectPath path;
-    reply >> path;
+
+    try {
+        auto reply = proxy->callMethod(method);
+        reply >> path;
+    } catch (std::exception& e) {
+        Debug::log(CRIT, "Couldn't connect to logind service ({})", e.what());
+        exit(1);
+    }
 
     Debug::log(LOG, "Using dbus path {}", path.c_str());
 


### PR DESCRIPTION
On non-systemd distros elogind may not be installed.

```c++
$ hypridle
[...]
[LOG] wayland done, registering dbus
Abort

(lldb) bt
* thread #1, name = 'hypridle', stop reason = signal SIGABRT
  * frame #0: 0x00000008259546aa libc.so.7`__sys_thr_kill at thr_kill.S:4
    frame #1: 0x00000008258c21a4 libc.so.7`__raise(s=6) at raise.c:48:10
    frame #2: 0x00000008259834f9 libc.so.7`abort at abort.c:61:8
    frame #3: 0x0000000823f66fe9 libcxxrt.so.1`report_failure(err=<unavailable>, thrown_exception=0x00002abde72930c0) at exception.cc:734:5
    frame #4: 0x00000008234c7560 libsdbus-c++.so.1`sdbus::internal::Proxy::SyncCallReplyData::waitForMethodReply(this=0x00000008203c3a58) at Proxy.cpp:194:9
    frame #5: 0x00000008234c68b2 libsdbus-c++.so.1`sdbus::internal::Proxy::sendMethodCallMessageAndWaitForReply(this=0x00002abde729d000, message=0x00000008203c3ea0, timeout=0) at Proxy.cpp:169:30
    frame #6: 0x00000008234c6744 libsdbus-c++.so.1`sdbus::internal::Proxy::callMethod(this=0x00002abde729d000, message=0x00000008203c3ea0, timeout=0) at Proxy.cpp:115:12
    frame #7: 0x00000000002468b8 hypridle`CHypridle::setupDBUS(this=0x00002abde72260a0) at Hypridle.cpp:389:38
    frame #8: 0x00000000002465c5 hypridle`CHypridle::run(this=0x00002abde72260a0) at Hypridle.cpp:81:5
    frame #9: 0x00000000002577b0 hypridle`main(argc=1, argv=0x00000008203c4268, envp=0x00000008203c4278) at main.cpp:29:18
    frame #10: 0x0000000825893daa libc.so.7`__libc_start1(argc=1, argv=0x00000008203c4268, env=0x00000008203c4278, cleanup=<unavailable>, mainX=(hypridle`main at main.cpp:5)) at libc_start1.c:157:7
    frame #11: 0x0000000000220fb0 hypridle`_start at crt1_s.S:83
(lldb) f 7
frame #7: 0x00000000002468b8 hypridle`CHypridle::setupDBUS(this=0x00002abde72260a0) at Hypridle.cpp:389:38
   386      auto proxy  = sdbus::createProxy("org.freedesktop.login1", "/org/freedesktop/login1");
   387      auto method = proxy->createMethodCall("org.freedesktop.login1.Manager", "GetSession");
   388      method << "auto";
-> 389      auto              reply = proxy->callMethod(method);
   390
   391      sdbus::ObjectPath path;
   392      reply >> path;
(lldb) f 4
frame #4: 0x00000008234c7560 libsdbus-c++.so.1`sdbus::internal::Proxy::SyncCallReplyData::waitForMethodReply(this=0x00000008203c3a58) at Proxy.cpp:194:9
   191      //arrived_ = false; // Necessary if SyncCallReplyData instance is thread_local
   192
   193      if (error_)
-> 194          throw *error_;
   195
   196      return std::move(reply_);
   197  }
```
