### PR TITLE
Fix typo and check correct grandchild PID in spawn()

### DIFF
--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -249,9 +249,9 @@ static void spawn(const std::string& args) {
     close(socket[1]);
     read(socket[0], &grandchild, sizeof(grandchild));
     close(socket[0]);
-    // clear child and leave child to init
+    // clear child and leave grandchild to init
     waitpid(child, NULL, 0);
-    if (child < 0) {
+    if (grandchild < 0) {
         Debug::log(LOG, "Failed to create the second fork");
         return;
     }


### PR DESCRIPTION
Some simple fixes to `spawn` to check the correct PID before displaying error message.