### PR TITLE
Added systemd service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ include_directories(
 set(CMAKE_CXX_STANDARD 23)
 add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-unused-value
 	-Wno-missing-field-initializers -Wno-narrowing)
+configure_file(systemd/hypridle.service.in systemd/hypridle.service @ONLY)
 
 # dependencies
 message(STATUS "Checking deps...")
@@ -73,3 +74,4 @@ protocol("staging/ext-idle-notify/ext-idle-notify-v1.xml" "ext-idle-notify-v1" f
 
 # Installation
 install(TARGETS hypridle)
+install(FILES ${CMAKE_BINARY_DIR}/systemd/hypridle.service DESTINATION "lib/systemd/user")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,4 +74,4 @@ protocol("staging/ext-idle-notify/ext-idle-notify-v1.xml" "ext-idle-notify-v1" f
 
 # Installation
 install(TARGETS hypridle)
-install(FILES ${CMAKE_BINARY_DIR}/systemd/hypridle.service DESTINATION "lib/systemd/user")
+install(FILES ${CMAKE_BINARY_DIR}/systemd/hypridle.service DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/user)

--- a/README.md
+++ b/README.md
@@ -38,15 +38,27 @@ will make those events ignored.
 
 ## Building & Installation
 
-Building:
+### Building:
 ```sh
 cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build
 cmake --build ./build --config Release --target hypridle -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 ```
 
-Installation:
+### Installation:
 ```sh
 sudo cmake --install build
+```
+
+### Usage:
+
+Hypridle should ideally be launched after logging in. This can be done by your compositor or by systemd.
+For example, for Hyprland, use the following in your `hyprland.conf`.
+```hyprlang
+exec-once = hypridle
+```
+If, instead, you want to have systemd do this for you, you'll just need to enable the service using
+```sh
+systemctl --user enable --now hypridle.service
 ```
 
 ## Flags

--- a/systemd/hypridle.service.in
+++ b/systemd/hypridle.service.in
@@ -7,7 +7,7 @@ ConditionEnvironment=WAYLAND_DISPLAY
 
 [Service]
 Type=simple
-ExecStart=@BINDIR@/hypridle
+ExecStart=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/hypridle
 Restart=on-failure
 
 [Install]

--- a/systemd/hypridle.service.in
+++ b/systemd/hypridle.service.in
@@ -1,0 +1,14 @@
+[Unit]
+Description=Hyprland's idle daemon
+Documentation=https://wiki.hyprland.org/Hypr-Ecosystem/hypridle
+PartOf=graphical-session.target
+After=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
+
+[Service]
+Type=simple
+ExecStart=@BINDIR@/hypridle
+Restart=on-failure
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
Hypridle can now be started and managed using systemd with
```sh
systemctl --user enable --now hypridle.service
```

This is useful as it allows an easier way to manage services that, like this, always run in the background. This way `systemctl start/stop/restart` commands can be used instead of `killall hypridle / nohup hypridle` or similar. I slightly updated the README to mention this different usage possibility.

Before this is ready to be merged, though, I'd need some feedback on the way I am currently configuring and installing the service file (see `CMakeLists.txt` and `systemd/hypridle.service.in`). The configuration part is not currently working though, I'm not really sure what I should be using to point at the directory the hypridle executable can be found in (usually `/usr/local/bin` if no extra cmdline args are given to smake).

Also, LMK if anything else should be changed, of course.