### PR TITLE
fix systemd service install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,4 +74,4 @@ protocol("staging/ext-idle-notify/ext-idle-notify-v1.xml" "ext-idle-notify-v1" f
 
 # Installation
 install(TARGETS hypridle)
-install(FILES ${CMAKE_BINARY_DIR}/systemd/hypridle.service DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/user)
+install(FILES ${CMAKE_BINARY_DIR}/systemd/hypridle.service DESTINATION "lib/systemd/user")


### PR DESCRIPTION
This partially reverts https://github.com/hyprwm/hypridle/commit/dad6ac14df38bd8d449677e8f998970af211b8b0

What @fufexan  suggested with `${CMAKE_INSTALL_LIBDIR}/systemd/user` doesn't seem to work consistently, reverting to `"lib/systemd/user"` for now is 100% a better idea. It's also what https://github.com/hyprwm/xdg-desktop-portal-hyprland/blob/master/CMakeLists.txt uses, which is why I was initially also doing that instead of LIBDIR