### PR TITLE
fix systemd service exec path

### DIFF
--- a/systemd/hypridle.service.in
+++ b/systemd/hypridle.service.in
@@ -7,7 +7,7 @@ ConditionEnvironment=WAYLAND_DISPLAY
 
 [Service]
 Type=simple
-ExecStart=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/hypridle
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/hypridle
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Yeah, here I am again, sorry for the inconvenience. I hate cmake. Why do those variables only work sometimes? Nobody knows.

Anyway, BINDIR appears to be just as unreliable as LIBDIR. Great.

As usual @fufexan lmk if you know of anything better (or yk, at least something that works).