### PR TITLE
Fix running without logind

### DIFF
--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -480,8 +480,7 @@ void CHypridle::setupDBUS() {
         m_sDBUSState.connection->addMatch("type='signal',path='" + path + "',interface='org.freedesktop.login1.Session'", handleDbusLogin, sdbus::floating_slot_t{});
         m_sDBUSState.connection->addMatch("type='signal',path='/org/freedesktop/login1',interface='org.freedesktop.login1.Manager'", handleDbusSleep, sdbus::floating_slot_t{});
     } catch (std::exception& e) {
-        Debug::log(CRIT, "Couldn't connect to logind service ({})", e.what());
-        exit(1);
+        Debug::log(WARN, "Couldn't connect to logind service ({})", e.what());
     }
 
     Debug::log(LOG, "Using dbus path {}", path.c_str());

--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -476,15 +476,15 @@ void CHypridle::setupDBUS() {
     try {
         auto reply = proxy->callMethod(method);
         reply >> path;
+
+        m_sDBUSState.connection->addMatch("type='signal',path='" + path + "',interface='org.freedesktop.login1.Session'", handleDbusLogin, sdbus::floating_slot_t{});
+        m_sDBUSState.connection->addMatch("type='signal',path='/org/freedesktop/login1',interface='org.freedesktop.login1.Manager'", handleDbusSleep, sdbus::floating_slot_t{});
     } catch (std::exception& e) {
         Debug::log(CRIT, "Couldn't connect to logind service ({})", e.what());
         exit(1);
     }
 
     Debug::log(LOG, "Using dbus path {}", path.c_str());
-
-    m_sDBUSState.connection->addMatch("type='signal',path='" + path + "',interface='org.freedesktop.login1.Session'", handleDbusLogin, sdbus::floating_slot_t{});
-    m_sDBUSState.connection->addMatch("type='signal',path='/org/freedesktop/login1',interface='org.freedesktop.login1.Manager'", handleDbusSleep, sdbus::floating_slot_t{});
 
     if (!IGNORE_SYSTEMD_INHIBIT) {
         m_sDBUSState.connection->addMatch("type='signal',path='/org/freedesktop/login1',interface='org.freedesktop.DBus.Properties'", handleDbusBlockInhibitsPropertyChanged, sdbus::floating_slot_t{});


### PR DESCRIPTION
Hypridle currently exits on systems without logind, but its functionality doesn't appear to depend on it.

This PR is marked as a draft because I haven't tested it on a system with logind yet, and I'm not sure if where the matches are moved is the best place.