### PR TITLE
typo fix hyprlock->hypridle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,4 +96,4 @@ install(FILES ${CMAKE_BINARY_DIR}/systemd/hypridle.service
 install(
   FILES ${CMAKE_SOURCE_DIR}/assets/example.conf
   DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/hypr
-  RENAME hyprlock.conf)
+  RENAME hypridle.conf)


### PR DESCRIPTION
I'm guessing this was a copy-paste typo.  I just tried to install the AUR packages for hypridle-git and hyprlock-git and they are colliding in /usr/share/hypr/hyprlock.conf - this should fix it!