### PR TITLE
Include Log.hpp in main

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 
 #include "config/ConfigManager.hpp"
 #include "core/Hypridle.hpp"
+#include "helpers/Log.hpp"
 
 int main(int argc, char** argv, char** envp) {
     std::string configPath;


### PR DESCRIPTION
This doesn't fix a compile error; it is already included because of `ConfigManager.hpp` including it. However, that should not be relied on as logging is also directly used in the main function.