### PR TITLE
Flush cout buffer automatically

### DIFF
--- a/src/helpers/Log.hpp
+++ b/src/helpers/Log.hpp
@@ -53,6 +53,6 @@ namespace Debug {
             std::cout << "] ";
         }
 
-        std::cout << std::vformat(fmt, std::make_format_args(args...)) << "\n";
+        std::cout << std::vformat(fmt, std::make_format_args(args...)) << std::endl;
     }
 };


### PR DESCRIPTION
Currently cout is never flushed. This is a problem because the actual flush timing is implementation defined and also changes whether it's piped or not. If you try to run `hypridle | tee idle.log` (simple example of trying to persist the log during development), then there is no log output.

This also means if hypridle were to crash, you don't lose all the messages that had the misfortune of not being already flushed.

Also looks like this same issue is present in Hyprland? Although over there it's less of an issue because of rollinglog and the file writer.