### PR TITLE
nix: add wayland-scanner native build input

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,6 +9,7 @@
   systemd,
   wayland,
   wayland-protocols,
+  wayland-scanner,
   version ? "git",
 }:
 stdenv.mkDerivation {
@@ -19,6 +20,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     cmake
     pkg-config
+    wayland-scanner
   ];
 
   buildInputs = [


### PR DESCRIPTION
Needed for https://github.com/NixOS/nixpkgs/pull/214906. I confirmed this builds on current nixos-unstable-small and nixos-unstable (i.e. with and without the wayland-scanner split).