### PR TITLE
core: handleDbusScreensaver must return uint32

### DIFF
--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -430,7 +430,7 @@ static void handleDbusBlockInhibitsPropertyChanged(sdbus::Message msg) {
     }
 }
 
-static int handleDbusScreensaver(std::string app, std::string reason, uint32_t cookie, bool inhibit, const char* sender) {
+static uint32_t handleDbusScreensaver(std::string app, std::string reason, uint32_t cookie, bool inhibit, const char* sender) {
     std::string ownerID = sender;
 
     if (!inhibit) {


### PR DESCRIPTION
Fix #97.