### PR TITLE
core: implement hyprlock-lock-notify-v1 functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .vscode/
 build/
 protocols/
+.clangd/
+.direnv/
+.cache/
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ message(STATUS "Checking deps...")
 
 find_package(Threads REQUIRED)
 find_package(PkgConfig REQUIRED)
+find_package(hyprwayland-scanner 0.4.4 REQUIRED)
 pkg_check_modules(
   deps
   REQUIRED
@@ -50,45 +51,47 @@ add_executable(hypridle ${SRCFILES})
 target_link_libraries(hypridle PRIVATE rt Threads::Threads PkgConfig::deps)
 
 # protocols
-find_program(WaylandScanner NAMES wayland-scanner)
-message(STATUS "Found WaylandScanner at ${WaylandScanner}")
-execute_process(
-  COMMAND pkg-config --variable=pkgdatadir wayland-protocols
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE WAYLAND_PROTOCOLS_DIR
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
+pkg_get_variable(WAYLAND_PROTOCOLS_DIR wayland-protocols pkgdatadir)
 message(STATUS "Found wayland-protocols at ${WAYLAND_PROTOCOLS_DIR}")
+pkg_get_variable(WAYLAND_SCANNER_PKGDATA_DIR wayland-scanner pkgdatadir)
+message(STATUS "Found wayland-scanner pkgdatadir at ${WAYLAND_SCANNER_PKGDATA_DIR}")
 
-function(protocol protoPath protoName external)
+pkg_check_modules(hyprland_protocols_dep REQUIRED IMPORTED_TARGET hyprland-protocols>=0.6.0)
+pkg_get_variable(HYPRLAND_PROTOCOLS hyprland-protocols pkgdatadir)
+message(STATUS "Found hyprland-protocols at ${HYPRLAND_PROTOCOLS}")
+
+function(protocolnew protoPath protoName external)
   if(external)
-    execute_process(
-      COMMAND ${WaylandScanner} client-header ${protoPath}
-              protocols/${protoName}-protocol.h
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-    execute_process(
-      COMMAND ${WaylandScanner} private-code ${protoPath}
-              protocols/${protoName}-protocol.c
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-    target_sources(hypridle PRIVATE protocols/${protoName}-protocol.c)
+    set(path ${protoPath})
   else()
-    execute_process(
-      COMMAND
-        ${WaylandScanner} client-header ${WAYLAND_PROTOCOLS_DIR}/${protoPath}
-        protocols/${protoName}-protocol.h
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-    execute_process(
-      COMMAND
-        ${WaylandScanner} private-code ${WAYLAND_PROTOCOLS_DIR}/${protoPath}
-        protocols/${protoName}-protocol.c
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-    target_sources(hypridle PRIVATE protocols/${protoName}-protocol.c)
+    set(path ${WAYLAND_PROTOCOLS_DIR}/${protoPath})
   endif()
+  message(STATUS "Full proto path: ${path}")
+  add_custom_command(
+    OUTPUT ${CMAKE_SOURCE_DIR}/protocols/${protoName}.cpp
+           ${CMAKE_SOURCE_DIR}/protocols/${protoName}.hpp
+    COMMAND hyprwayland-scanner --client ${path}/${protoName}.xml
+            ${CMAKE_SOURCE_DIR}/protocols/
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+  target_sources(hypridle PRIVATE protocols/${protoName}.cpp
+                                   protocols/${protoName}.hpp)
+endfunction()
+function(protocolWayland)
+  add_custom_command(
+    OUTPUT ${CMAKE_SOURCE_DIR}/protocols/wayland.cpp
+           ${CMAKE_SOURCE_DIR}/protocols/wayland.hpp
+    COMMAND hyprwayland-scanner --wayland-enums --client
+            ${WAYLAND_SCANNER_PKGDATA_DIR}/wayland.xml ${CMAKE_SOURCE_DIR}/protocols/
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+  target_sources(hypridle PRIVATE protocols/wayland.cpp protocols/wayland.hpp)
 endfunction()
 
 make_directory(${CMAKE_SOURCE_DIR}/protocols) # we don't ship any custom ones so
-                                              # the dir won't be there
-protocol("staging/ext-idle-notify/ext-idle-notify-v1.xml" "ext-idle-notify-v1"
-         false)
+
+protocolwayland()
+
+protocolnew("staging/ext-idle-notify" "ext-idle-notify-v1" false)
+protocolnew("${HYPRLAND_PROTOCOLS}/protocols" "hyprland-lock-notify-v1" true)
 
 # Installation
 install(TARGETS hypridle)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ pkg_check_modules(
   IMPORTED_TARGET
   wayland-client
   wayland-protocols
-  hyprlang>=0.4.0
+  hyprlang>=0.6.0
   hyprutils>=0.2.0
   sdbus-c++>=0.2.0)
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ will make those events ignored.
  - wayland-protocols
  - hyprlang >= 0.4.0
  - sdbus-c++
+ - hyprwayland-scanner
 
 ## Building & Installation
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,28 @@
 {
   "nodes": {
+    "hyprland-protocols": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1737556638,
+        "narHash": "sha256-laKgI3mr2qz6tas/q3tuGPxMdsGhBi/w+HO+hO2f1AY=",
+        "owner": "hyprwm",
+        "repo": "hyprland-protocols",
+        "rev": "4c75dd5c015c8a0e5a34c6d02a018a650f57feb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-protocols",
+        "type": "github"
+      }
+    },
     "hyprlang": {
       "inputs": {
         "hyprutils": [
@@ -13,6 +36,8 @@
         ]
       },
       "locked": {
+        "lastModified": 1734364628,
+        "narHash": "sha256-ii8fzJfI953n/EmIxVvq64ZAwhvwuuPHWfGd61/mJG8=",
         "lastModified": 1737634606,
         "narHash": "sha256-W7W87Cv6wqZ9PHegI6rH1+ve3zJPiyevMFf0/HwdbCQ=",
         "owner": "hyprwm",
@@ -49,6 +74,29 @@
         "type": "github"
       }
     },
+    "hyprwayland-scanner": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1735493474,
+        "narHash": "sha256-fktzv4NaqKm94VAkAoVqO/nqQlw+X0/tJJNAeCSfzK4=",
+        "owner": "hyprwm",
+        "repo": "hyprwayland-scanner",
+        "rev": "de913476b59ee88685fdc018e77b8f6637a2ae0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprwayland-scanner",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1737469691,
@@ -67,8 +115,10 @@
     },
     "root": {
       "inputs": {
+        "hyprland-protocols": "hyprland-protocols",
         "hyprlang": "hyprlang",
         "hyprutils": "hyprutils",
+        "hyprwayland-scanner": "hyprwayland-scanner",
         "nixpkgs": "nixpkgs",
         "systems": "systems"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734364628,
-        "narHash": "sha256-ii8fzJfI953n/EmIxVvq64ZAwhvwuuPHWfGd61/mJG8=",
+        "lastModified": 1737634606,
+        "narHash": "sha256-W7W87Cv6wqZ9PHegI6rH1+ve3zJPiyevMFf0/HwdbCQ=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "16e59c1eb13d9fb6de066f54e7555eb5e8a4aba5",
+        "rev": "f41271d35cc0f370d300413d756c2677f386af9d",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733502241,
-        "narHash": "sha256-KAUNC4Dgq8WQjYov5auBw/usaHixhacvb7cRDd0AG/k=",
+        "lastModified": 1737632363,
+        "narHash": "sha256-X9I8POSlHxBVjD0fiX1O2j7U9Zi1+4rIkrsyHP0uHXY=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "104117aed6dd68561be38b50f218190aa47f2cd8",
+        "rev": "006620eb29d54ea9086538891404c78563d1bae1",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734119587,
-        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
+        "lastModified": 1737469691,
+        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,18 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.systems.follows = "systems";
     };
+
+    hyprland-protocols = {
+      url = "github:hyprwm/hyprland-protocols";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.systems.follows = "systems";
+    };
+
+    hyprwayland-scanner = {
+      url = "github:hyprwm/hyprwayland-scanner";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.systems.follows = "systems";
+    };
   };
 
   outputs = {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,11 +1,13 @@
 {
-  lib,
-  stdenv,
   cmake,
-  pkg-config,
+  hyprland-protocols,
   hyprlang,
   hyprutils,
+  hyprwayland-scanner,
+  lib,
+  pkg-config,
   sdbus-cpp,
+  stdenv,
   systemd,
   wayland,
   wayland-protocols,
@@ -19,11 +21,13 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     cmake
+    hyprwayland-scanner
     pkg-config
     wayland-scanner
   ];
 
   buildInputs = [
+    hyprland-protocols
     hyprlang
     hyprutils
     sdbus-cpp

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -13,8 +13,10 @@ in {
   default = inputs.self.overlays.hypridle;
 
   hypridle = lib.composeManyExtensions [
+    inputs.hyprland-protocols.overlays.default
     inputs.hyprlang.overlays.default
     inputs.hyprutils.overlays.default
+    inputs.hyprwayland-scanner.overlays.default
     inputs.self.overlays.sdbuscpp
     (final: prev: {
       hypridle = prev.callPackage ./default.nix {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -23,10 +23,13 @@ void CConfigManager::init() {
 
     m_config.addConfigValue("general:lock_cmd", Hyprlang::STRING{""});
     m_config.addConfigValue("general:unlock_cmd", Hyprlang::STRING{""});
+    m_config.addConfigValue("general:on_lock_cmd", Hyprlang::STRING{""});
+    m_config.addConfigValue("general:on_unlock_cmd", Hyprlang::STRING{""});
     m_config.addConfigValue("general:before_sleep_cmd", Hyprlang::STRING{""});
     m_config.addConfigValue("general:after_sleep_cmd", Hyprlang::STRING{""});
     m_config.addConfigValue("general:ignore_dbus_inhibit", Hyprlang::INT{0});
     m_config.addConfigValue("general:ignore_systemd_inhibit", Hyprlang::INT{0});
+    m_config.addConfigValue("general:inhibit_sleep", Hyprlang::INT{2});
 
     m_config.commence();
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -80,11 +80,3 @@ Hyprlang::CParseResult CConfigManager::postParse() {
 std::vector<CConfigManager::STimeoutRule> CConfigManager::getRules() {
     return m_vRules;
 }
-
-std::string CConfigManager::getOnTimeoutCommand() {
-    return m_vRules.front().onTimeout;
-}
-
-void* const* CConfigManager::getValuePtr(const std::string& name) {
-    return m_config.getConfigValuePtr(name.c_str())->getDataStaticPtr();
-}

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -18,9 +18,12 @@ class CConfigManager {
         std::string onResume  = "";
     };
 
-    std::string               getOnTimeoutCommand();
     std::vector<STimeoutRule> getRules();
-    void* const*              getValuePtr(const std::string& name);
+
+    template <typename T>
+    Hyprlang::CSimpleConfigValue<T> getValue(const std::string& name) {
+        return Hyprlang::CSimpleConfigValue<T>(&m_config, name.c_str());
+    }
 
   private:
     Hyprlang::CConfig         m_config;

--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -92,9 +92,9 @@ void CHypridle::run() {
                    "Compositor is missing hyprland-lock-notify-v1!\n"
                    "general:inhibit_sleep=3, general:on_lock_cmd and general:on_unlock_cmd will not work.");
 
-    const auto INHIBIT  = g_pConfigManager->getValue<Hyprlang::INT>("general:inhibit_sleep");
-    const auto SLEEPCMD = g_pConfigManager->getValue<Hyprlang::STRING>("general:before_sleep_cmd");
-    const auto LOCKCMD  = g_pConfigManager->getValue<Hyprlang::STRING>("general:lock_cmd");
+    static const auto INHIBIT  = g_pConfigManager->getValue<Hyprlang::INT>("general:inhibit_sleep");
+    static const auto SLEEPCMD = g_pConfigManager->getValue<Hyprlang::STRING>("general:before_sleep_cmd");
+    static const auto LOCKCMD  = g_pConfigManager->getValue<Hyprlang::STRING>("general:lock_cmd");
 
     switch (*INHIBIT) {
         case 0: // disabled
@@ -350,7 +350,7 @@ void CHypridle::onLocked() {
     Debug::log(LOG, "Wayland session got locked");
     m_isLocked = true;
 
-    const auto LOCKCMD = g_pConfigManager->getValue<Hyprlang::STRING>("general:on_lock_cmd");
+    static const auto LOCKCMD = g_pConfigManager->getValue<Hyprlang::STRING>("general:on_lock_cmd");
     if (*LOCKCMD)
         spawn(*LOCKCMD);
 
@@ -365,7 +365,7 @@ void CHypridle::onUnlocked() {
     if (m_inhibitSleepBehavior == SLEEP_INHIBIT_LOCK_NOTIFY)
         inhibitSleep();
 
-    const auto UNLOCKCMD = g_pConfigManager->getValue<Hyprlang::STRING>("general:on_unlock_cmd");
+    static const auto UNLOCKCMD = g_pConfigManager->getValue<Hyprlang::STRING>("general:on_unlock_cmd");
     if (*UNLOCKCMD)
         spawn(*UNLOCKCMD);
 }
@@ -407,8 +407,8 @@ bool CHypridle::unregisterDbusInhibitCookies(const std::string& ownerID) {
 
 static void handleDbusLogin(sdbus::Message msg) {
     // lock & unlock
-    const auto LOCKCMD   = g_pConfigManager->getValue<Hyprlang::STRING>("general:lock_cmd");
-    const auto UNLOCKCMD = g_pConfigManager->getValue<Hyprlang::STRING>("general:unlock_cmd");
+    static const auto LOCKCMD   = g_pConfigManager->getValue<Hyprlang::STRING>("general:lock_cmd");
+    static const auto UNLOCKCMD = g_pConfigManager->getValue<Hyprlang::STRING>("general:unlock_cmd");
 
     Debug::log(LOG, "Got dbus .Session");
 
@@ -439,8 +439,8 @@ static void handleDbusSleep(sdbus::Message msg) {
     bool toSleep = true;
     msg >> toSleep;
 
-    const auto SLEEPCMD      = g_pConfigManager->getValue<Hyprlang::STRING>("general:before_sleep_cmd");
-    const auto AFTERSLEEPCMD = g_pConfigManager->getValue<Hyprlang::STRING>("general:after_sleep_cmd");
+    static const auto SLEEPCMD      = g_pConfigManager->getValue<Hyprlang::STRING>("general:before_sleep_cmd");
+    static const auto AFTERSLEEPCMD = g_pConfigManager->getValue<Hyprlang::STRING>("general:after_sleep_cmd");
 
     Debug::log(LOG, "Got PrepareForSleep from dbus with sleep {}", toSleep);
 
@@ -536,8 +536,8 @@ static void handleDbusNameOwnerChanged(sdbus::Message msg) {
 }
 
 void CHypridle::setupDBUS() {
-    const auto        IGNOREDBUSINHIBIT    = g_pConfigManager->getValue<Hyprlang::INT>("general:ignore_dbus_inhibit");
-    const auto        IGNORESYSTEMDINHIBIT = g_pConfigManager->getValue<Hyprlang::INT>("general:ignore_systemd_inhibit");
+    static const auto IGNOREDBUSINHIBIT    = g_pConfigManager->getValue<Hyprlang::INT>("general:ignore_dbus_inhibit");
+    static const auto IGNORESYSTEMDINHIBIT = g_pConfigManager->getValue<Hyprlang::INT>("general:ignore_systemd_inhibit");
 
     auto              systemConnection = sdbus::createSystemBusConnection();
     auto              proxy            = sdbus::createProxy(*systemConnection, sdbus::ServiceName{"org.freedesktop.login1"}, sdbus::ObjectPath{"/org/freedesktop/login1"});

--- a/src/defines.hpp
+++ b/src/defines.hpp
@@ -1,0 +1,8 @@
+#include "wayland.hpp"
+#include "ext-idle-notify-v1.hpp"
+#include "hyprland-lock-notify-v1.hpp"
+
+#include <hyprutils/memory/WeakPtr.hpp>
+using namespace Hyprutils::Memory;
+#define SP CSharedPointer
+#define WP CWeakPointer


### PR DESCRIPTION
Requires the protocol and https://github.com/hyprwm/Hyprland/pull/9092

TODO: 
- [x] wiki-mr
- [x] CMake hl proto version bump

If users use hypridle and hyprlock, this PR will fix https://github.com/hyprwm/hyprlock/issues/547 and https://github.com/hyprwm/hyprlock/issues/633 (dupe).

`general:inhibit_sleep` is 2 (auto) per default.
Hypridle will check if either `before_sleep_cmd` contains "hyprlock" or if `before_sleep_cmd` contains "lock-session" and `lock_cmd` contains "hyprlock".
In those cases, hypridle will inhibit sleep until we receive the locked event from hyprland-lock-notify-v1. This behavior can be manually selected with `general:inhibit_sleep=3` and should work for all session-lock apps. 
`general:inhibit_sleep=0` is the current behaviour.
``general:inhibit_sleep=1` will lock sleep until we launched the `before_sleep_cmd`.