### PR TITLE
core: fix sleep delay and simplify process spawning

### DIFF
--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -19,7 +19,7 @@ CHypridle::CHypridle() {
     }
 }
 
-void setupSignals(void) {
+static void setupSignals() {
     struct sigaction sa;
 
     // don't transform child processes into zombies and don't handle SIGCHLD.
@@ -259,7 +259,7 @@ static void spawn(const std::string& args) {
         sigemptyset(&sa.sa_mask);
         sa.sa_flags   = 0;
         sa.sa_handler = SIG_DFL;
-        sigaction(SIGCHLD, &sa, NULL);
+        sigaction(SIGCHLD, &sa, nullptr);
 
         execl("/bin/sh", "/bin/sh", "-c", args.c_str(), nullptr);
         _exit(1);
@@ -440,7 +440,7 @@ static void handleDbusSleep(sdbus::Message msg) {
         g_pHypridle->handleInhibitOnDbusSleep(toSleep);
 }
 
-void handleDbusBlockInhibits(const std::string& inhibits) {
+static void handleDbusBlockInhibits(const std::string& inhibits) {
     static auto inhibited = false;
     // BlockInhibited is a colon separated list of inhibit types. Wrapping in additional colons allows for easier checking if there are active inhibits we are interested in
     auto inhibits_ = ":" + inhibits + ":";

--- a/src/core/Hypridle.hpp
+++ b/src/core/Hypridle.hpp
@@ -49,8 +49,6 @@ class CHypridle {
     void               inhibitSleep();
     void               uninhibitSleep();
 
-    void               closeInhibitFd();
-
   private:
     void    setupDBUS();
     void    enterEventLoop();

--- a/src/core/Hypridle.hpp
+++ b/src/core/Hypridle.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 #include <sdbus-c++/sdbus-c++.h>
+#include <hyprutils/os/FileDescriptor.hpp>
 #include <condition_variable>
 
 #include "wayland.hpp"
@@ -48,6 +49,8 @@ class CHypridle {
     void               inhibitSleep();
     void               uninhibitSleep();
 
+    void               closeInhibitFd();
+
   private:
     void    setupDBUS();
     void    enterEventLoop();
@@ -83,7 +86,7 @@ class CHypridle {
         std::unique_ptr<sdbus::IProxy>               login;
         std::vector<std::unique_ptr<sdbus::IObject>> screenSaverObjects;
         std::vector<SDbusInhibitCookie>              inhibitCookies;
-        sdbus::UnixFd                                sleepInhibitFd;
+        Hyprutils::OS::CFileDescriptor               sleepInhibitFd;
     } m_sDBUSState;
 
     struct {


### PR DESCRIPTION
So releasing the sleep inhibitor did not work properly so far, cause of forked fds.
That lead to suspend taking max delay seconds, which defaults to 5. (I used a `sleep 4 && hyprlock` to test that the system does not go sleep, so I did not notice.)

~~As can be seen in my comments, for some reason we still need to explicitly close the fd in the child process despite setting O_CLOEXEC, which is weird.~~

I removed the second fork cause we don't need it in hypridle, which also allowed to set SA_NOCLDWAIT and stuff which is nice to have for a daemon process.