### PR TITLE
feat: support `source` option for additional config files

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1,6 +1,10 @@
 #include "ConfigManager.hpp"
+#include "../helpers/Log.hpp"
+#include "../helpers/MiscFunctions.hpp"
 #include <hyprutils/path/Path.hpp>
 #include <filesystem>
+#include <glob.h>
+#include <cstring>
 
 static std::string getMainConfigPath() {
     static const auto paths = Hyprutils::Path::findConfig("hypridle");
@@ -13,6 +17,19 @@ static std::string getMainConfigPath() {
 CConfigManager::CConfigManager(std::string configPath) :
     m_config(configPath.empty() ? getMainConfigPath().c_str() : configPath.c_str(), Hyprlang::SConfigOptions{.throwAllErrors = true, .allowMissingConfig = false}) {
     ;
+    configCurrentPath = configPath.empty() ? getMainConfigPath() : configPath;
+}
+
+static Hyprlang::CParseResult handleSource(const char* c, const char* v) {
+    const std::string      VALUE   = v;
+    const std::string      COMMAND = c;
+
+    const auto             RESULT = g_pConfigManager->handleSource(COMMAND, VALUE);
+
+    Hyprlang::CParseResult result;
+    if (RESULT.has_value())
+        result.setError(RESULT.value().c_str());
+    return result;
 }
 
 void CConfigManager::init() {
@@ -30,6 +47,8 @@ void CConfigManager::init() {
     m_config.addConfigValue("general:ignore_dbus_inhibit", Hyprlang::INT{0});
     m_config.addConfigValue("general:ignore_systemd_inhibit", Hyprlang::INT{0});
     m_config.addConfigValue("general:inhibit_sleep", Hyprlang::INT{2});
+
+    m_config.registerHandler(&::handleSource, "source", {.allowFlags = false});
 
     m_config.commence();
 
@@ -79,4 +98,49 @@ Hyprlang::CParseResult CConfigManager::postParse() {
 
 std::vector<CConfigManager::STimeoutRule> CConfigManager::getRules() {
     return m_vRules;
+}
+
+std::optional<std::string> CConfigManager::handleSource(const std::string& command, const std::string& rawpath) {
+    if (rawpath.length() < 2) {
+        return "source path " + rawpath + " bogus!";
+    }
+    std::unique_ptr<glob_t, void (*)(glob_t*)> glob_buf{new glob_t, [](glob_t* g) { globfree(g); }};
+    memset(glob_buf.get(), 0, sizeof(glob_t));
+
+    const auto CURRENTDIR = std::filesystem::path(configCurrentPath).parent_path().string();
+
+    if (auto r = glob(absolutePath(rawpath, CURRENTDIR).c_str(), GLOB_TILDE, nullptr, glob_buf.get()); r != 0) {
+        std::string err = std::format("source= globbing error: {}", r == GLOB_NOMATCH ? "found no match" : GLOB_ABORTED ? "read error" : "out of memory");
+        Debug::log(ERR, "{}", err);
+        return err;
+    }
+
+    for (size_t i = 0; i < glob_buf->gl_pathc; i++) {
+        const auto PATH = absolutePath(glob_buf->gl_pathv[i], CURRENTDIR);
+
+        if (PATH.empty() || PATH == configCurrentPath) {
+            Debug::log(WARN, "source= skipping invalid path");
+            continue;
+        }
+
+        if (!std::filesystem::is_regular_file(PATH)) {
+            if (std::filesystem::exists(PATH)) {
+                Debug::log(WARN, "source= skipping non-file {}", PATH);
+                continue;
+            }
+
+            Debug::log(ERR, "source= file doesnt exist");
+            return "source file " + PATH + " doesn't exist!";
+        }
+
+        // allow for nested config parsing
+        auto backupConfigPath = configCurrentPath;
+        configCurrentPath     = PATH;
+
+        m_config.parseFile(PATH.c_str());
+
+        configCurrentPath = backupConfigPath;
+    }
+
+    return {};
 }

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -18,7 +18,9 @@ class CConfigManager {
         std::string onResume  = "";
     };
 
-    std::vector<STimeoutRule> getRules();
+    std::vector<STimeoutRule>  getRules();
+    std::optional<std::string> handleSource(const std::string&, const std::string&);
+    std::string                configCurrentPath;
 
     template <typename T>
     Hyprlang::CSimpleConfigValue<T> getValue(const std::string& name) {

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -4,6 +4,7 @@
 
 #include <hyprlang.hpp>
 
+#include <set>
 #include <vector>
 #include <memory>
 
@@ -21,6 +22,7 @@ class CConfigManager {
     std::vector<STimeoutRule>  getRules();
     std::optional<std::string> handleSource(const std::string&, const std::string&);
     std::string                configCurrentPath;
+    std::set<std::string>      alreadyIncludedSourceFiles;
 
     template <typename T>
     Hyprlang::CSimpleConfigValue<T> getValue(const std::string& name) {

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -1,0 +1,19 @@
+#include <filesystem>
+
+#include "MiscFunctions.hpp"
+
+std::string absolutePath(const std::string& rawpath, const std::string& currentDir) {
+    std::filesystem::path path(rawpath);
+
+    // Handling where rawpath starts with '~'
+    if (!rawpath.empty() && rawpath[0] == '~') {
+        static const char* const ENVHOME = getenv("HOME");
+        path                             = std::filesystem::path(ENVHOME) / path.relative_path().string().substr(2);
+    }
+
+    // Handling e.g. ./, ../
+    if (path.is_relative())
+        return std::filesystem::weakly_canonical(std::filesystem::path(currentDir) / path);
+    else
+        return std::filesystem::weakly_canonical(path);
+}

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string>
+
+std::string absolutePath(const std::string&, const std::string&);


### PR DESCRIPTION
Hey :wave: 

This PR implements #33.

a896871df5b31de8e4e83140ccb82feba5bdbc86: the code comes from hyprlock
8d4c6ead8fd9f6b51867df91e6a7837a3ab0bb41: implement a circular dependency protection. hyprlock (and hypridle without that commit) don't start and show no errors if there's a circular dependency.