### PR TITLE
Add ability to ignore Wayland idle inhibitors

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737556638,
-        "narHash": "sha256-laKgI3mr2qz6tas/q3tuGPxMdsGhBi/w+HO+hO2f1AY=",
+        "lastModified": 1743714874,
+        "narHash": "sha256-yt8F7NhMFCFHUHy/lNjH/pjZyIDFNk52Q4tivQ31WFo=",
         "owner": "hyprwm",
         "repo": "hyprland-protocols",
-        "rev": "4c75dd5c015c8a0e5a34c6d02a018a650f57feb5",
+        "rev": "3a5c2bda1c1a4e55cc1330c782547695a93f05b2",
         "type": "github"
       },
       "original": {
@@ -36,13 +36,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734364628,
-        "narHash": "sha256-ii8fzJfI953n/EmIxVvq64ZAwhvwuuPHWfGd61/mJG8=",
-        "lastModified": 1737634606,
-        "narHash": "sha256-W7W87Cv6wqZ9PHegI6rH1+ve3zJPiyevMFf0/HwdbCQ=",
+        "lastModified": 1747484975,
+        "narHash": "sha256-+LAQ81HBwG0lwshHlWe0kfWg4KcChIPpnwtnwqmnoEU=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "f41271d35cc0f370d300413d756c2677f386af9d",
+        "rev": "163c83b3db48a17c113729c220a60b94596c9291",
         "type": "github"
       },
       "original": {
@@ -61,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737632363,
-        "narHash": "sha256-X9I8POSlHxBVjD0fiX1O2j7U9Zi1+4rIkrsyHP0uHXY=",
+        "lastModified": 1748696825,
+        "narHash": "sha256-miMCjlQGg+C0GiVJy5V8Bn1ysi3LiaN226/BwWcAEQE=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "006620eb29d54ea9086538891404c78563d1bae1",
+        "rev": "f1d0879444e1ed86e3df4ee273b916d651b36f4f",
         "type": "github"
       },
       "original": {
@@ -84,11 +82,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735493474,
-        "narHash": "sha256-fktzv4NaqKm94VAkAoVqO/nqQlw+X0/tJJNAeCSfzK4=",
+        "lastModified": 1747584298,
+        "narHash": "sha256-PH9qZqWLHvSBQiUnA0NzAyQA3tu2no2z8kz0ZeHWj4w=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "de913476b59ee88685fdc018e77b8f6637a2ae0b",
+        "rev": "e511882b9c2e1d7a75d45d8fddd2160daeafcbc3",
         "type": "github"
       },
       "original": {
@@ -99,11 +97,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737469691,
-        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
+        "lastModified": 1748693115,
+        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
+        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
         "type": "github"
       },
       "original": {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -46,6 +46,7 @@ void CConfigManager::init() {
     m_config.addConfigValue("general:after_sleep_cmd", Hyprlang::STRING{""});
     m_config.addConfigValue("general:ignore_dbus_inhibit", Hyprlang::INT{0});
     m_config.addConfigValue("general:ignore_systemd_inhibit", Hyprlang::INT{0});
+    m_config.addConfigValue("general:ignore_wayland_inhibit", Hyprlang::INT{0});
     m_config.addConfigValue("general:inhibit_sleep", Hyprlang::INT{2});
 
     // track the file in the circular dependency chain

--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -56,7 +56,7 @@ void CHypridle::run() {
 
     static const auto IGNOREWAYLANDINHIBIT = g_pConfigManager->getValue<Hyprlang::INT>("general:ignore_wayland_inhibit");
 
-    const auto RULES = g_pConfigManager->getRules();
+    const auto        RULES = g_pConfigManager->getRules();
     m_sWaylandIdleState.listeners.resize(RULES.size());
 
     Debug::log(LOG, "found {} rules", RULES.size());
@@ -68,9 +68,11 @@ void CHypridle::run() {
         l.onTimeout   = r.onTimeout;
 
         if (!*IGNOREWAYLANDINHIBIT)
-            l.notification = makeShared<CCExtIdleNotificationV1>(m_sWaylandIdleState.notifier->sendGetIdleNotification(r.timeout * 1000 /* ms */, m_sWaylandState.seat->resource()));
+            l.notification =
+                makeShared<CCExtIdleNotificationV1>(m_sWaylandIdleState.notifier->sendGetIdleNotification(r.timeout * 1000 /* ms */, m_sWaylandState.seat->resource()));
         else
-            l.notification = makeShared<CCExtIdleNotificationV1>(m_sWaylandIdleState.notifier->sendGetInputIdleNotification(r.timeout * 1000 /* ms */, m_sWaylandState.seat->resource()));
+            l.notification =
+                makeShared<CCExtIdleNotificationV1>(m_sWaylandIdleState.notifier->sendGetInputIdleNotification(r.timeout * 1000 /* ms */, m_sWaylandState.seat->resource()));
 
         l.notification->setData(&m_sWaylandIdleState.listeners[i]);
 
@@ -296,7 +298,7 @@ void CHypridle::onInhibit(bool lock) {
     if (m_iInhibitLocks == 0 && isIdled) {
         static const auto IGNOREWAYLANDINHIBIT = g_pConfigManager->getValue<Hyprlang::INT>("general:ignore_wayland_inhibit");
 
-        const auto RULES = g_pConfigManager->getRules();
+        const auto        RULES = g_pConfigManager->getRules();
 
         for (size_t i = 0; i < RULES.size(); ++i) {
             auto&       l = m_sWaylandIdleState.listeners[i];
@@ -305,9 +307,11 @@ void CHypridle::onInhibit(bool lock) {
             l.notification->sendDestroy();
 
             if (!*IGNOREWAYLANDINHIBIT)
-                l.notification = makeShared<CCExtIdleNotificationV1>(m_sWaylandIdleState.notifier->sendGetIdleNotification(r.timeout * 1000 /* ms */, m_sWaylandState.seat->resource()));
+                l.notification =
+                    makeShared<CCExtIdleNotificationV1>(m_sWaylandIdleState.notifier->sendGetIdleNotification(r.timeout * 1000 /* ms */, m_sWaylandState.seat->resource()));
             else
-                l.notification = makeShared<CCExtIdleNotificationV1>(m_sWaylandIdleState.notifier->sendGetInputIdleNotification(r.timeout * 1000 /* ms */, m_sWaylandState.seat->resource()));
+                l.notification =
+                    makeShared<CCExtIdleNotificationV1>(m_sWaylandIdleState.notifier->sendGetInputIdleNotification(r.timeout * 1000 /* ms */, m_sWaylandState.seat->resource()));
 
             l.notification->setData(&m_sWaylandIdleState.listeners[i]);
 


### PR DESCRIPTION
config: general:ignore_wayland_inhibit (bool)

If the config value general:ignore_wayland_inhibit is true, the CCExtIdleNotifierV1 function used will be: sendGetInputIdleNotification. This instructs the compositor (hyprland) to return all idle/resume events, ignoring any Wayland inhibitors.

If the config value general:ignore_wayland_inhibit is false/unset, it will use the default function sendGetIdleNotification, which obeys Wayland inhibitors.