### PR TITLE
core: fix dbus inhibit lock counting

### DIFF
--- a/src/core/Hypridle.hpp
+++ b/src/core/Hypridle.hpp
@@ -44,7 +44,7 @@ class CHypridle {
     SDbusInhibitCookie getDbusInhibitCookie(uint32_t cookie);
     void               registerDbusInhibitCookie(SDbusInhibitCookie& cookie);
     bool               unregisterDbusInhibitCookie(const SDbusInhibitCookie& cookie);
-    bool               unregisterDbusInhibitCookies(const std::string& ownerID);
+    size_t             unregisterDbusInhibitCookies(const std::string& ownerID);
 
     void               handleInhibitOnDbusSleep(bool toSleep);
     void               inhibitSleep();


### PR DESCRIPTION
Fixes #74 (root cause)

Fixes #111

  **Double-decrement race (#74)**: When a client disconnects, both NameOwnerChanged and cleanup UnInhibit messages call onInhibit(false) for the same cookie, decrementing the counter twice and triggering "BUG THIS: inhibit locks < 0" warnings.

  **Multi-cookie under-decrement (#111)**: When a client with N cookies disconnects, onInhibit(false) is only called once instead of N times, causing permanent lock leaks that break hypridle.