### PR TITLE
Fixed an unnecessary error when there is no default config

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -15,7 +15,7 @@ static std::string getMainConfigPath() {
 }
 
 CConfigManager::CConfigManager(std::string configPath) :
-    m_config(configPath.empty() ? getMainConfigPath().c_str() : configPath.c_str(), Hyprlang::SConfigOptions{.throwAllErrors = true, .allowMissingConfig = false}) {
+    m_config(configPath.empty() ? getMainConfigPath().c_str() : configPath.c_str(), Hyprlang::SConfigOptions{.throwAllErrors = true, .allowMissingConfig = true}) {
     ;
     configCurrentPath = configPath.empty() ? getMainConfigPath() : configPath;
     configHeadPath    = configCurrentPath;


### PR DESCRIPTION
Crashing when no config exists is fine and expected unless a user manually specifies a config location. If so, it shouldn't matter that a default config does or doesn't exist. This fix retains the crash when no valid override is specified but eliminates it when one does.

This is particularly useful if using hypridle with greetd, in which the greetd user doesn't have a home directory.

Resolves #176