### PR TITLE
fix: allow hypridle -c to run without default conf

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -5,11 +5,15 @@
 #include <filesystem>
 #include <glob.h>
 #include <cstring>
+#include <expected>
 
-static std::string getMainConfigPath(const std::string& overridePath = "") {
+static std::expected<std::string, std::error_code> getMainConfigPath(const std::string& overridePath = "") {
+    namespace fs = std::filesystem;
+
     if (!overridePath.empty()) {
-        if (!std::filesystem::exists(overridePath)) {
-            throw std::runtime_error("Provided config path does not exist: " + overridePath);
+        std::error_code ec;
+        if (!fs::exists(overridePath, ec)) {
+            return std::unexpected(std::make_error_code(std::errc::no_such_file_or_directory));
         }
         return overridePath;
     }
@@ -20,18 +24,23 @@ static std::string getMainConfigPath(const std::string& overridePath = "") {
         return paths.first.value();
     }
 
-    throw std::runtime_error(
-        "[ERR] Could not find hypridle.conf in:\n"
-        "   $HOME/.config/hypr, /etc/xdg/hypr, $XDG_CONFIG_HOME/hypr or any $XDG_CONFIG_DIRS/hypr directories\n"
-    );
+    return std::unexpected(std::make_error_code(std::errc::no_such_file_or_directory));
 }
 
 CConfigManager::CConfigManager(std::string configPath) :
-    m_config(getMainConfigPath(configPath).c_str(),
-             Hyprlang::SConfigOptions{.throwAllErrors = true, .allowMissingConfig = false})
+    /* allowMissingConfig = 'true' to avoid library-level exceptions during initialization.
+    Existence is guaranteed by the path check below. */
+    m_config(getMainConfigPath(configPath).value_or("").c_str(),
+             Hyprlang::SConfigOptions{.throwAllErrors = false, .allowMissingConfig = true})
 {
-    configCurrentPath = getMainConfigPath(configPath);
-    configHeadPath = configCurrentPath;
+    auto pathResult = getMainConfigPath(configPath);
+
+    if (!pathResult) {
+        return;
+    }
+
+    configCurrentPath = *pathResult;
+    configHeadPath    = configCurrentPath;
 
     Debug::log(LOG, "Using config file: {}", configCurrentPath);
 }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -6,19 +6,34 @@
 #include <glob.h>
 #include <cstring>
 
-static std::string getMainConfigPath() {
+static std::string getMainConfigPath(const std::string& overridePath = "") {
+    if (!overridePath.empty()) {
+        if (!std::filesystem::exists(overridePath)) {
+            throw std::runtime_error("Provided config path does not exist: " + overridePath);
+        }
+        return overridePath;
+    }
+
     static const auto paths = Hyprutils::Path::findConfig("hypridle");
-    if (paths.first.has_value())
+
+    if (paths.first.has_value()) {
         return paths.first.value();
-    else
-        throw std::runtime_error("Could not find config in HOME, XDG_CONFIG_HOME, XDG_CONFIG_DIRS or /etc/hypr.");
+    }
+
+    throw std::runtime_error(
+        "[ERR] Could not find hypridle.conf in:\n"
+        "   $HOME/.config/hypr, /etc/xdg/hypr, $XDG_CONFIG_HOME/hypr or any $XDG_CONFIG_DIRS/hypr directories\n"
+    );
 }
 
 CConfigManager::CConfigManager(std::string configPath) :
-    m_config(configPath.empty() ? getMainConfigPath().c_str() : configPath.c_str(), Hyprlang::SConfigOptions{.throwAllErrors = true, .allowMissingConfig = false}) {
-    ;
-    configCurrentPath = configPath.empty() ? getMainConfigPath() : configPath;
-    configHeadPath    = configCurrentPath;
+    m_config(getMainConfigPath(configPath).c_str(),
+             Hyprlang::SConfigOptions{.throwAllErrors = true, .allowMissingConfig = false})
+{
+    configCurrentPath = getMainConfigPath(configPath);
+    configHeadPath = configCurrentPath;
+
+    Debug::log(LOG, "Using config file: {}", configCurrentPath);
 }
 
 static Hyprlang::CParseResult handleSource(const char* c, const char* v) {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -12,17 +12,15 @@ static std::expected<std::string, std::error_code> getMainConfigPath(const std::
 
     if (!overridePath.empty()) {
         std::error_code ec;
-        if (!fs::exists(overridePath, ec)) {
+        if (!fs::exists(overridePath, ec))
             return std::unexpected(std::make_error_code(std::errc::no_such_file_or_directory));
-        }
         return overridePath;
     }
 
     static const auto paths = Hyprutils::Path::findConfig("hypridle");
 
-    if (paths.first.has_value()) {
+    if (paths.first.has_value())
         return paths.first.value();
-    }
 
     return std::unexpected(std::make_error_code(std::errc::no_such_file_or_directory));
 }
@@ -35,9 +33,8 @@ CConfigManager::CConfigManager(std::string configPath) :
 {
     auto pathResult = getMainConfigPath(configPath);
 
-    if (!pathResult) {
+    if (!pathResult)
         return;
-    }
 
     configCurrentPath = *pathResult;
     configHeadPath    = configCurrentPath;
@@ -134,9 +131,9 @@ std::vector<CConfigManager::STimeoutRule> CConfigManager::getRules() {
 }
 
 std::optional<std::string> CConfigManager::handleSource(const std::string& command, const std::string& rawpath) {
-    if (rawpath.length() < 2) {
+    if (rawpath.length() < 2)
         return "source path " + rawpath + " bogus!";
-    }
+
     std::unique_ptr<glob_t, void (*)(glob_t*)> glob_buf{new glob_t, [](glob_t* g) { globfree(g); }};
     memset(glob_buf.get(), 0, sizeof(glob_t));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "config/ConfigManager.hpp"
 #include "core/Hypridle.hpp"
 #include "helpers/Log.hpp"
+#include <memory>
 
 int main(int argc, char** argv, char** envp) {
     std::string configPath;
@@ -51,16 +52,21 @@ int main(int argc, char** argv, char** envp) {
         }
     }
 
-    try {
-        g_pConfigManager = std::make_unique<CConfigManager>(configPath);
-        g_pConfigManager->init();
-    } catch (const char* err) {
-        Debug::log(CRIT, "ConfigManager threw: {}", err);
-        std::string strerr = err;
-        if (strerr.contains("File does not exist"))
-            Debug::log(NONE, "           Make sure you have a config.");
+    g_pConfigManager = std::make_unique<CConfigManager>(configPath);
+
+    if (g_pConfigManager->configCurrentPath.empty()) {
+        if (!configPath.empty()) {
+            Debug::log(CRIT, "ConfigManager: Specified file not found: {}\n", configPath);
+        } else {
+            Debug::log(CRIT, "ConfigManager: No hypridle.conf file found in:");
+            Debug::log(NONE, "    $XDG_CONFIG_HOME/hypr/, ~/.config/hypr/, [XDG_CONFIG_DIRS]/hypr/, /etc/xdg/hypr/\n");
+            Debug::log(NONE, "Create a config or specify one manually:");
+            Debug::log(NONE, "    hypridle -c /path/to/conf");
+        }
         return 1;
     }
+
+    g_pConfigManager->init();
 
     g_pHypridle = std::make_unique<CHypridle>();
     g_pHypridle->run();


### PR DESCRIPTION
- checks for -c and if file exists before running Hyprutils
- update getMainConfigPath runtime_error message to be more explicit in reason for failure
- add LOG message for the config file path

Ran into this while configuring nixos module.. was getting SIGABRT because I was placing the configuration files in /etc/hypr/hypridle.conf instead of /etc/xdg/hypr. Updated error message to help clarify reason for failure and https://github.com/hyprwm/hypridle/issues/176

Passing -c but still looking for a default file feels a little counter-intuitive so I updated the getMainConfigPath function. This also would resolve https://github.com/hyprwm/hypridle/pull/184

Tested various use cases and seems to be working as intended..

Example with found hypridle.conf in default paths:
```
➜ hypridle 
[LOG] Using config file: /etc/xdg/hypr/hypridle.conf
[LOG] Registered timeout rule for 1200s:
      on-timeout: /nix/store/bigkpra9jw48fip69q4wndsf4kb3d2w9-systemd-258.3/bin/loginctl lock-session
...
```

Passing -c argument (works with missing default config)
```
➜ ls -lah /etc/xdg/hypr/hypridle.conf || hypridle -c /tmp/hypridle.conf 
ls: cannot access '/etc/xdg/hypr/hypridle.conf': No such file or directory
[LOG] Using config file: /tmp/hypridle.conf
[LOG] Registered timeout rule for 1200s:
      on-timeout: /nix/store/bigkpra9jw48fip69q4wndsf4kb3d2w9-systemd-258.3/bin/loginctl lock-session
...
```

Passing -c to not existent file:
```
➜ hypridle -c /tmp/bad.conf
terminate called after throwing an instance of 'std::runtime_error'
  what():  Provided config path does not exist: /tmp/bad.conf
fish: Job 1, 'hypridle -c /tmp/bad.conf' terminated by signal SIGABRT (Abort)

```

No default config file found:
```
➜ hypridle
terminate called after throwing an instance of 'std::runtime_error'
  what():  [ERR] Could not find hypridle.conf in:
   $HOME/.config/hypr, /etc/xdg/hypr, $XDG_CONFIG_HOME/hypr or any $XDG_CONFIG_DIRS/hypr directories

fish: Job 1, 'hypridle' terminated by signal SIGABRT (Abort)
```