### PR TITLE
core: don't skip on-resume when on-timeout already fired

### DIFF
--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -269,16 +269,21 @@ void CHypridle::onIdled(SIdleListener* pListener) {
     }
 
     Debug::log(LOG, "Running {}", pListener->onTimeout);
+    pListener->onTimeoutFired = true;
     spawn(pListener->onTimeout);
 }
 
 void CHypridle::onResumed(SIdleListener* pListener) {
     Debug::log(LOG, "Resumed: rule {:x}", (uintptr_t)pListener);
     isIdled = false;
-    if (g_pHypridle->m_iInhibitLocks > 0 && !pListener->ignoreInhibit) {
-        Debug::log(LOG, "Ignoring from onResumed(), inhibit locks: {}", g_pHypridle->m_iInhibitLocks);
+
+    // If on-timeout never actually executed (was inhibited), skip on-resume too
+    if (!pListener->onTimeoutFired) {
+        Debug::log(LOG, "Skipping onResumed: onTimeout was inhibited for rule {:x}", (uintptr_t)pListener);
         return;
     }
+
+    pListener->onTimeoutFired = false;
 
     if (pListener->onRestore.empty()) {
         Debug::log(LOG, "Ignoring, onRestore is empty.");

--- a/src/core/Hypridle.hpp
+++ b/src/core/Hypridle.hpp
@@ -17,10 +17,11 @@ class CHypridle {
     CHypridle();
 
     struct SIdleListener {
-        SP<CCExtIdleNotificationV1> notification  = nullptr;
-        std::string                 onTimeout     = "";
-        std::string                 onRestore     = "";
-        bool                        ignoreInhibit = false;
+        SP<CCExtIdleNotificationV1> notification     = nullptr;
+        std::string                 onTimeout        = "";
+        std::string                 onRestore        = "";
+        bool                        ignoreInhibit    = false;
+        bool                        onTimeoutFired   = false;
     };
 
     struct SDbusInhibitCookie {


### PR DESCRIPTION
## Problem

When a listener's `on-timeout` has already executed (e.g. DPMS off), and a ScreenSaver inhibit lock arrives **afterward** (e.g. from a notification sound), `onResumed()` is blocked by the inhibit lock check. The user moves the mouse or presses a key, hypridle resets its idle timers, but the `on-resume` command never runs — leaving monitors stuck off with no way to recover.

## Root cause

Both `onIdled()` and `onResumed()` check `m_iInhibitLocks > 0` and return early. This is correct for `onIdled()` (don't fire timeout while inhibited), but wrong for `onResumed()` when `on-timeout` has already executed — the side-effect happened and must be undone regardless of inhibit state.

## Fix

Add a per-listener `onTimeoutFired` flag. Set it when `on-timeout` actually executes. In `onResumed()`, check this flag instead of the inhibit lock count:

- `onTimeoutFired == true` → run `on-resume` unconditionally, clear flag
- `onTimeoutFired == false` → skip `on-resume` (timeout was inhibited, nothing to undo)

Fixes #128