### PR TITLE
core: add per-listener condition_cmd with retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ listener {
     timeout = 500                            # in seconds
     on-timeout = notify-send "You are idle!" # command to run when timeout has passed
     on-resume = notify-send "Welcome back!"  # command to run when activity is detected after timeout has fired.
-    condition_cmd =                          # if set, run this command before on-timeout. Exit 0 = proceed, non-zero = defer
-    condition_retry = 30                     # retry interval in seconds when condition_cmd defers (default: 30)
+    # condition_cmd =                        # if set, run this command before on-timeout. Exit 0 = proceed, non-zero = defer
+    # condition_retry = 30                   # retry interval in seconds when condition_cmd defers (default: 30)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ listener {
     timeout = 500                            # in seconds
     on-timeout = notify-send "You are idle!" # command to run when timeout has passed
     on-resume = notify-send "Welcome back!"  # command to run when activity is detected after timeout has fired.
+    condition_cmd =                          # if set, run this command before on-timeout. Exit 0 = proceed, non-zero = defer
+    condition_retry = 30                     # retry interval in seconds when condition_cmd defers (default: 30)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ listener {
     timeout = 500                            # in seconds
     on-timeout = notify-send "You are idle!" # command to run when timeout has passed
     on-resume = notify-send "Welcome back!"  # command to run when activity is detected after timeout has fired.
-    # condition_cmd =                        # if set, run this command before on-timeout. Exit 0 = proceed, non-zero = defer
-    # condition_retry = 30                   # retry interval in seconds when condition_cmd defers (default: 30)
+    condition_cmd =                          # if set, run this command before on-timeout. Exit 0 = proceed, non-zero = defer
+    condition_retry = 0                      # retry interval in seconds when condition_cmd defers (default: 0, no retry)
 }
 ```
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -61,7 +61,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("listener", "on-resume", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("listener", "ignore_inhibit", Hyprlang::INT{0});
     m_config.addSpecialConfigValue("listener", "condition_cmd", Hyprlang::STRING{""});
-    m_config.addSpecialConfigValue("listener", "condition_retry", Hyprlang::INT{30});
+    m_config.addSpecialConfigValue("listener", "condition_retry", Hyprlang::INT{0});
 
     m_config.addConfigValue("general:lock_cmd", Hyprlang::STRING{""});
     m_config.addConfigValue("general:unlock_cmd", Hyprlang::STRING{""});

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -60,6 +60,8 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("listener", "on-timeout", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("listener", "on-resume", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("listener", "ignore_inhibit", Hyprlang::INT{0});
+    m_config.addSpecialConfigValue("listener", "condition_cmd", Hyprlang::STRING{""});
+    m_config.addSpecialConfigValue("listener", "condition_retry", Hyprlang::INT{30});
 
     m_config.addConfigValue("general:lock_cmd", Hyprlang::STRING{""});
     m_config.addConfigValue("general:unlock_cmd", Hyprlang::STRING{""});
@@ -109,6 +111,8 @@ Hyprlang::CParseResult CConfigManager::postParse() {
         rule.onResume  = std::any_cast<Hyprlang::STRING>(m_config.getSpecialConfigValue("listener", "on-resume", k.c_str()));
 
         rule.ignoreInhibit = std::any_cast<Hyprlang::INT>(m_config.getSpecialConfigValue("listener", "ignore_inhibit", k.c_str()));
+        rule.conditionCmd  = std::any_cast<Hyprlang::STRING>(m_config.getSpecialConfigValue("listener", "condition_cmd", k.c_str()));
+        rule.conditionRetry = std::any_cast<Hyprlang::INT>(m_config.getSpecialConfigValue("listener", "condition_retry", k.c_str()));
 
         if (timeout == -1) {
             result.setError("Category has a missing timeout setting");
@@ -119,8 +123,8 @@ Hyprlang::CParseResult CConfigManager::postParse() {
     }
 
     for (auto& r : m_vRules) {
-        Debug::log(LOG, "Registered timeout rule for {}s:\n      on-timeout: {}\n      on-resume: {}\n      ignore_inhibit: {}", r.timeout, r.onTimeout, r.onResume,
-                   r.ignoreInhibit);
+        Debug::log(LOG, "Registered timeout rule for {}s:\n      on-timeout: {}\n      on-resume: {}\n      ignore_inhibit: {}\n      condition_cmd: {}\n      condition_retry: {}",
+                   r.timeout, r.onTimeout, r.onResume, r.ignoreInhibit, r.conditionCmd, r.conditionRetry);
     }
 
     return result;

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -19,7 +19,7 @@ class CConfigManager {
         std::string onResume       = "";
         bool        ignoreInhibit  = false;
         std::string conditionCmd   = "";
-        int64_t     conditionRetry = 30;
+        int64_t     conditionRetry = 0;
     };
 
     std::vector<STimeoutRule>  getRules();

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -14,10 +14,12 @@ class CConfigManager {
     void init();
 
     struct STimeoutRule {
-        uint64_t    timeout       = 0;
-        std::string onTimeout     = "";
-        std::string onResume      = "";
-        bool        ignoreInhibit = false;
+        uint64_t    timeout        = 0;
+        std::string onTimeout      = "";
+        std::string onResume       = "";
+        bool        ignoreInhibit  = false;
+        std::string conditionCmd   = "";
+        int64_t     conditionRetry = 30;
     };
 
     std::vector<STimeoutRule>  getRules();

--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -65,9 +65,11 @@ void CHypridle::run() {
     for (size_t i = 0; i < RULES.size(); ++i) {
         auto&       l   = m_sWaylandIdleState.listeners[i];
         const auto& r   = RULES[i];
-        l.onRestore     = r.onResume;
-        l.onTimeout     = r.onTimeout;
-        l.ignoreInhibit = r.ignoreInhibit;
+        l.onRestore      = r.onResume;
+        l.onTimeout      = r.onTimeout;
+        l.ignoreInhibit  = r.ignoreInhibit;
+        l.conditionCmd   = r.conditionCmd;
+        l.conditionRetry = r.conditionRetry;
 
         if (*IGNOREWAYLANDINHIBIT || r.ignoreInhibit)
             l.notification =
@@ -141,6 +143,45 @@ void CHypridle::run() {
         inhibitSleep();
     enterEventLoop();
 }
+
+static int64_t nowMonotonic() {
+    return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+static bool runConditionCmd(const std::string& cmd) {
+    Debug::log(LOG, "Running condition_cmd: {}", cmd);
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        Debug::log(ERR, "Failed to fork for condition_cmd");
+        return false;
+    }
+
+    if (pid == 0) {
+        execl("/bin/sh", "/bin/sh", "-c", cmd.c_str(), nullptr);
+        _exit(127);
+    }
+
+    // Wait with 5s timeout
+    for (int i = 0; i < 50; i++) {
+        int status = 0;
+        pid_t ret = waitpid(pid, &status, WNOHANG);
+        if (ret > 0) {
+            int exitCode = WIFEXITED(status) ? WEXITSTATUS(status) : 1;
+            Debug::log(LOG, "condition_cmd exited with {}", exitCode);
+            return exitCode == 0;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    // Timeout — kill and return false
+    Debug::log(WARN, "condition_cmd timed out after 5s, killing");
+    kill(pid, SIGKILL);
+    waitpid(pid, nullptr, 0);
+    return false;
+}
+
+static void spawn(const std::string& args);
 
 void CHypridle::enterEventLoop() {
 
@@ -238,6 +279,24 @@ void CHypridle::enterEventLoop() {
             ret = wl_display_dispatch_pending(m_sWaylandState.display);
             wl_display_flush(m_sWaylandState.display);
         } while (ret > 0);
+
+        // Check condition_cmd retries for pending listeners
+        const auto now = nowMonotonic();
+        for (auto& l : m_sWaylandIdleState.listeners) {
+            if (!l.conditionPending || now < l.conditionRetryAt)
+                continue;
+
+            Debug::log(LOG, "Retrying condition_cmd for rule {:x}", (uintptr_t)&l);
+            if (runConditionCmd(l.conditionCmd)) {
+                l.conditionPending = false;
+                l.onTimeoutFired = true;
+                Debug::log(LOG, "Condition met, running {}", l.onTimeout);
+                spawn(l.onTimeout);
+            } else {
+                l.conditionRetryAt = now + l.conditionRetry;
+                Debug::log(LOG, "Condition still not met, retrying in {}s", l.conditionRetry);
+            }
+        }
     }
 
     Debug::log(ERR, "[core] Terminated");
@@ -268,6 +327,16 @@ void CHypridle::onIdled(SIdleListener* pListener) {
         return;
     }
 
+    // Check condition_cmd before firing on-timeout
+    if (!pListener->conditionCmd.empty()) {
+        if (!runConditionCmd(pListener->conditionCmd)) {
+            Debug::log(LOG, "condition_cmd blocked on-timeout, retrying in {}s", pListener->conditionRetry);
+            pListener->conditionPending = true;
+            pListener->conditionRetryAt = nowMonotonic() + pListener->conditionRetry;
+            return;
+        }
+    }
+
     Debug::log(LOG, "Running {}", pListener->onTimeout);
     pListener->onTimeoutFired = true;
     spawn(pListener->onTimeout);
@@ -276,6 +345,7 @@ void CHypridle::onIdled(SIdleListener* pListener) {
 void CHypridle::onResumed(SIdleListener* pListener) {
     Debug::log(LOG, "Resumed: rule {:x}", (uintptr_t)pListener);
     isIdled = false;
+    pListener->conditionPending = false;
 
     // If on-timeout never actually executed (was inhibited), skip on-resume too
     if (!pListener->onTimeoutFired) {

--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -330,9 +330,13 @@ void CHypridle::onIdled(SIdleListener* pListener) {
     // Check condition_cmd before firing on-timeout
     if (!pListener->conditionCmd.empty()) {
         if (!runConditionCmd(pListener->conditionCmd)) {
-            Debug::log(LOG, "condition_cmd blocked on-timeout, retrying in {}s", pListener->conditionRetry);
-            pListener->conditionPending = true;
-            pListener->conditionRetryAt = nowMonotonic() + pListener->conditionRetry;
+            if (pListener->conditionRetry > 0) {
+                Debug::log(LOG, "condition_cmd blocked on-timeout, retrying in {}s", pListener->conditionRetry);
+                pListener->conditionPending = true;
+                pListener->conditionRetryAt = nowMonotonic() + pListener->conditionRetry;
+            } else {
+                Debug::log(LOG, "condition_cmd blocked on-timeout, no retry configured");
+            }
             return;
         }
     }

--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -237,7 +237,7 @@ void CHypridle::enterEventLoop() {
 
         std::unique_lock lk(m_sEventLoopInternals.loopMutex);
         if (!m_sEventLoopInternals.shouldProcess) // avoid a lock if a thread managed to request something already since we .unlock()ed
-            m_sEventLoopInternals.loopSignal.wait(lk, [this] { return m_sEventLoopInternals.shouldProcess == true; }); // wait for events
+            m_sEventLoopInternals.loopSignal.wait_for(lk, std::chrono::seconds(5), [this] { return m_sEventLoopInternals.shouldProcess == true; }); // wait for events or timeout (for condition_cmd retries)
 
         m_sEventLoopInternals.loopRequestMutex.lock(); // lock incoming events
 

--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -349,7 +349,18 @@ void CHypridle::onIdled(SIdleListener* pListener) {
 void CHypridle::onResumed(SIdleListener* pListener) {
     Debug::log(LOG, "Resumed: rule {:x}", (uintptr_t)pListener);
     isIdled = false;
-    pListener->conditionPending = false;
+
+    // Any input means the user is no longer idle for *any* rule, so cancel all
+    // pending condition retries, not just this listener's. Per-listener clearing
+    // is insufficient: onInhibit() destroys and recreates idle notifications when
+    // the inhibit count drops to 0 while idle (e.g. a media player toggling the
+    // screensaver inhibit). That orphans a long-timeout rule's pending retry --
+    // its old notification is gone, and the recreated one won't fire resume until
+    // a fresh full timeout elapses, which never happens if the user stays active.
+    // The retry then waits on conditionPending alone and fires when the condition
+    // finally clears, despite continuous input. Clearing all on any resume fixes it.
+    for (auto& l : m_sWaylandIdleState.listeners)
+        l.conditionPending = false;
 
     // If on-timeout never actually executed (was inhibited), skip on-resume too
     if (!pListener->onTimeoutFired) {

--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -151,34 +151,15 @@ static int64_t nowMonotonic() {
 static bool runConditionCmd(const std::string& cmd) {
     Debug::log(LOG, "Running condition_cmd: {}", cmd);
 
-    pid_t pid = fork();
-    if (pid < 0) {
-        Debug::log(ERR, "Failed to fork for condition_cmd");
+    Hyprutils::OS::CProcess proc("/bin/sh", {"-c", cmd});
+    if (!proc.runSync()) {
+        Debug::log(ERR, "Failed to run condition_cmd: {}", cmd);
         return false;
     }
 
-    if (pid == 0) {
-        execl("/bin/sh", "/bin/sh", "-c", cmd.c_str(), nullptr);
-        _exit(127);
-    }
-
-    // Wait with 5s timeout
-    for (int i = 0; i < 50; i++) {
-        int status = 0;
-        pid_t ret = waitpid(pid, &status, WNOHANG);
-        if (ret > 0) {
-            int exitCode = WIFEXITED(status) ? WEXITSTATUS(status) : 1;
-            Debug::log(LOG, "condition_cmd exited with {}", exitCode);
-            return exitCode == 0;
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-
-    // Timeout — kill and return false
-    Debug::log(WARN, "condition_cmd timed out after 5s, killing");
-    kill(pid, SIGKILL);
-    waitpid(pid, nullptr, 0);
-    return false;
+    const int exitCode = proc.exitCode();
+    Debug::log(LOG, "condition_cmd exited with {}", exitCode);
+    return exitCode == 0;
 }
 
 static void spawn(const std::string& args);

--- a/src/core/Hypridle.hpp
+++ b/src/core/Hypridle.hpp
@@ -23,7 +23,7 @@ class CHypridle {
         bool                        ignoreInhibit     = false;
         bool                        onTimeoutFired    = false;
         std::string                 conditionCmd      = "";
-        int64_t                     conditionRetry    = 30;
+        int64_t                     conditionRetry    = 0;
         bool                        conditionPending  = false;
         int64_t                     conditionRetryAt  = 0;
     };

--- a/src/core/Hypridle.hpp
+++ b/src/core/Hypridle.hpp
@@ -17,11 +17,15 @@ class CHypridle {
     CHypridle();
 
     struct SIdleListener {
-        SP<CCExtIdleNotificationV1> notification     = nullptr;
-        std::string                 onTimeout        = "";
-        std::string                 onRestore        = "";
-        bool                        ignoreInhibit    = false;
-        bool                        onTimeoutFired   = false;
+        SP<CCExtIdleNotificationV1> notification      = nullptr;
+        std::string                 onTimeout         = "";
+        std::string                 onRestore         = "";
+        bool                        ignoreInhibit     = false;
+        bool                        onTimeoutFired    = false;
+        std::string                 conditionCmd      = "";
+        int64_t                     conditionRetry    = 30;
+        bool                        conditionPending  = false;
+        int64_t                     conditionRetryAt  = 0;
     };
 
     struct SDbusInhibitCookie {


### PR DESCRIPTION
## Summary

Add `condition_cmd` and `condition_retry` per-listener config options. When set, `condition_cmd` is executed as a shell command before `on-timeout` fires. Exit 0 = proceed, non-zero = defer.

This is built on top of #192 (on-resume fix).

## Problem

There is no way to conditionally gate a listener's `on-timeout` on external state. Users currently work around this with wrapper scripts in `on-timeout`, but those have a fundamental problem: the timer is consumed after firing, so if the script decides not to act, hypridle won't retry until the next full idle cycle.

Common use cases that need this:
- Don't suspend while SSH sessions are active (#170, #188)
- Don't suspend while system is under load (#188)
- Different behavior on AC vs battery (#94, #67)
- Don't suspend while audio is playing (#27)

## Solution

Two new per-listener config options:

```ini
listener {
    timeout = 900
    on-timeout = systemctl suspend
    condition_cmd = ~/scripts/check-suspend.sh  # exit 0 = proceed, non-zero = defer
    condition_retry = 30                         # retry every 30s while idle (default: 0, no retry)
}
```

When `condition_cmd` returns non-zero:
- `on-timeout` is deferred (not fired)
- If `condition_retry` is set (> 0), hypridle retries every `condition_retry` seconds while the user remains idle
- When the condition clears (exit 0), `on-timeout` fires immediately
- User activity cancels any pending retry
- If `condition_retry` is not set (default: 0), `on-timeout` is skipped for this idle cycle

The command has a 5-second execution timeout to prevent hanging.

## Examples

**Don't suspend during SSH sessions:**
```bash
#!/bin/sh
ss -tn sport = :22 | grep -q ESTAB && exit 1
exit 0
```

**Don't suspend while system is under load:**
```bash
#!/bin/sh
load=$(awk '{printf "%d", $1}' /proc/loadavg)
[ "$load" -gt 2 ] && exit 1
exit 0
```

**Don't suspend while audio is playing:**
```bash
#!/bin/sh
pactl list sink-inputs short | grep -q RUNNING && exit 1
exit 0
```

**Different timeout on battery (skip suspend on AC):**
```bash
#!/bin/sh
[ "$(cat /sys/class/power_supply/AC/online)" = "1" ] && exit 1
exit 0
```

## Closes / Addresses

- Closes #94 (feature request for exactly this)
- Fixes #128, #163 (on-resume after inhibit — via the `timeoutExecuted` tracking, see #192)
- Addresses #170 (script-controlled suspend timing)
- Addresses #188 (system load as idle heuristic)
- Addresses #67 (AC vs battery behavior)
- Addresses #27 (audio inhibit — solvable via condition_cmd script)