### PR TITLE
core: add after_lock/before_lock listeners and various bug fixes

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -39,6 +39,8 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("listener", "on-timeout", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("listener", "on-resume", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("listener", "ignore_inhibit", Hyprlang::INT{0});
+    m_config.addSpecialConfigValue("listener", "after_lock", Hyprlang::INT{0});
+    m_config.addSpecialConfigValue("listener", "before_lock", Hyprlang::INT{0});
 
     m_config.addConfigValue("general:lock_cmd", Hyprlang::STRING{""});
     m_config.addConfigValue("general:unlock_cmd", Hyprlang::STRING{""});
@@ -88,8 +90,20 @@ Hyprlang::CParseResult CConfigManager::postParse() {
         rule.onResume  = std::any_cast<Hyprlang::STRING>(m_config.getSpecialConfigValue("listener", "on-resume", k.c_str()));
 
         rule.ignoreInhibit = std::any_cast<Hyprlang::INT>(m_config.getSpecialConfigValue("listener", "ignore_inhibit", k.c_str()));
+        rule.afterLock     = std::any_cast<Hyprlang::INT>(m_config.getSpecialConfigValue("listener", "after_lock", k.c_str()));
+        rule.beforeLock    = std::any_cast<Hyprlang::INT>(m_config.getSpecialConfigValue("listener", "before_lock", k.c_str()));
 
-        if (timeout == -1) {
+        if (rule.afterLock && rule.beforeLock) {
+            result.setError("A listener cannot have both after_lock and before_lock set");
+            continue;
+        }
+
+        if ((rule.afterLock || rule.beforeLock) && timeout != -1 && timeout > 0) {
+            result.setError("A listener cannot have both timeout and after_lock/before_lock set");
+            continue;
+        }
+
+        if (!rule.afterLock && !rule.beforeLock && timeout == -1) {
             result.setError("Category has a missing timeout setting");
             continue;
         }
@@ -98,8 +112,13 @@ Hyprlang::CParseResult CConfigManager::postParse() {
     }
 
     for (auto& r : m_vRules) {
-        Debug::log(LOG, "Registered timeout rule for {}s:\n      on-timeout: {}\n      on-resume: {}\n      ignore_inhibit: {}", r.timeout, r.onTimeout, r.onResume,
-                   r.ignoreInhibit);
+        if (r.afterLock)
+            Debug::log(LOG, "Registered after_lock rule:\n      on-timeout: {}\n      on-resume: {}", r.onTimeout, r.onResume);
+        else if (r.beforeLock)
+            Debug::log(LOG, "Registered before_lock rule:\n      on-timeout: {}\n      on-resume: {}", r.onTimeout, r.onResume);
+        else
+            Debug::log(LOG, "Registered timeout rule for {}s:\n      on-timeout: {}\n      on-resume: {}\n      ignore_inhibit: {}", r.timeout, r.onTimeout, r.onResume,
+                       r.ignoreInhibit);
     }
 
     return result;

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -18,6 +18,8 @@ class CConfigManager {
         std::string onTimeout     = "";
         std::string onResume      = "";
         bool        ignoreInhibit = false;
+        bool        afterLock     = false;
+        bool        beforeLock    = false;
     };
 
     std::vector<STimeoutRule>  getRules();

--- a/src/core/Hypridle.cpp
+++ b/src/core/Hypridle.cpp
@@ -68,18 +68,11 @@ void CHypridle::run() {
         l.onRestore     = r.onResume;
         l.onTimeout     = r.onTimeout;
         l.ignoreInhibit = r.ignoreInhibit;
+        l.afterLock     = r.afterLock;
+        l.beforeLock    = r.beforeLock;
 
-        if (*IGNOREWAYLANDINHIBIT || r.ignoreInhibit)
-            l.notification =
-                makeShared<CCExtIdleNotificationV1>(m_sWaylandIdleState.notifier->sendGetInputIdleNotification(r.timeout * 1000 /* ms */, m_sWaylandState.seat->resource()));
-        else
-            l.notification =
-                makeShared<CCExtIdleNotificationV1>(m_sWaylandIdleState.notifier->sendGetIdleNotification(r.timeout * 1000 /* ms */, m_sWaylandState.seat->resource()));
-
-        l.notification->setData(&m_sWaylandIdleState.listeners[i]);
-
-        l.notification->setIdled([this](CCExtIdleNotificationV1* n) { onIdled((CHypridle::SIdleListener*)n->data()); });
-        l.notification->setResumed([this](CCExtIdleNotificationV1* n) { onResumed((CHypridle::SIdleListener*)n->data()); });
+        if (!r.afterLock && !r.beforeLock)
+            l.notification = createIdleNotification(r.timeout * 1000 /* ms */, *IGNOREWAYLANDINHIBIT || r.ignoreInhibit, &m_sWaylandIdleState.listeners[i]);
     }
 
     wl_display_roundtrip(m_sWaylandState.display);
@@ -161,20 +154,31 @@ void CHypridle::enterEventLoop() {
         },
     };
 
-    std::thread pollThr([this, &pollfds, &pollfdsCount]() {
+    nfds_t                       threadPollfdsCount = pollfdsCount;
+    std::thread                  pollThr([this, &pollfds, threadPollfdsCount]() {
         while (1) {
-            int ret = poll(pollfds, pollfdsCount, 5000 /* 5 seconds, reasonable. It's because we might need to terminate */);
+            int ret = poll(pollfds, threadPollfdsCount, 5000 /* 5 seconds, reasonable. It's because we might need to terminate */);
             if (ret < 0) {
                 Debug::log(CRIT, "[core] Polling fds failed with {}", errno);
                 m_bTerminate = true;
-                exit(1);
+                {
+                    std::lock_guard<std::mutex> lg(m_sEventLoopInternals.loopRequestMutex);
+                    m_sEventLoopInternals.shouldProcess = true;
+                    m_sEventLoopInternals.loopSignal.notify_all();
+                }
+                return;
             }
 
-            for (size_t i = 0; i < pollfdsCount; ++i) {
+            for (size_t i = 0; i < threadPollfdsCount; ++i) {
                 if (pollfds[i].revents & POLLHUP) {
                     Debug::log(CRIT, "[core] Disconnected from pollfd id {}", i);
                     m_bTerminate = true;
-                    exit(1);
+                    {
+                        std::lock_guard<std::mutex> lg(m_sEventLoopInternals.loopRequestMutex);
+                        m_sEventLoopInternals.shouldProcess = true;
+                        m_sEventLoopInternals.loopSignal.notify_all();
+                    }
+                    return;
                 }
             }
 
@@ -190,15 +194,16 @@ void CHypridle::enterEventLoop() {
         }
     });
 
+    std::unique_lock<std::mutex> requestLock(m_sEventLoopInternals.loopRequestMutex);
+
     while (1) { // dbus events
-        // wait for being awakened
-        m_sEventLoopInternals.loopRequestMutex.unlock(); // unlock, we are ready to take events
+        requestLock.unlock();
 
         std::unique_lock lk(m_sEventLoopInternals.loopMutex);
         if (!m_sEventLoopInternals.shouldProcess) // avoid a lock if a thread managed to request something already since we .unlock()ed
             m_sEventLoopInternals.loopSignal.wait(lk, [this] { return m_sEventLoopInternals.shouldProcess == true; }); // wait for events
 
-        m_sEventLoopInternals.loopRequestMutex.lock(); // lock incoming events
+        requestLock.lock();
 
         if (m_bTerminate)
             break;
@@ -259,7 +264,7 @@ void CHypridle::onIdled(SIdleListener* pListener) {
     Debug::log(LOG, "Idled: rule {:x}", (uintptr_t)pListener);
     isIdled = true;
     if (g_pHypridle->m_iInhibitLocks > 0 && !pListener->ignoreInhibit) {
-        Debug::log(LOG, "Ignoring from onIdled(), inhibit locks: {}", g_pHypridle->m_iInhibitLocks);
+        Debug::log(LOG, "Ignoring from onIdled(), inhibit locks: {}", g_pHypridle->m_iInhibitLocks.load());
         return;
     }
 
@@ -294,11 +299,25 @@ void CHypridle::onResumed(SIdleListener* pListener) {
     spawn(pListener->onRestore);
 }
 
+SP<CCExtIdleNotificationV1> CHypridle::createIdleNotification(uint32_t timeoutMs, bool ignoreInhibit, SIdleListener* listener) {
+    SP<CCExtIdleNotificationV1> notification;
+    if (ignoreInhibit)
+        notification = makeShared<CCExtIdleNotificationV1>(m_sWaylandIdleState.notifier->sendGetInputIdleNotification(timeoutMs, m_sWaylandState.seat->resource()));
+    else
+        notification = makeShared<CCExtIdleNotificationV1>(m_sWaylandIdleState.notifier->sendGetIdleNotification(timeoutMs, m_sWaylandState.seat->resource()));
+
+    notification->setData(listener);
+    notification->setIdled([this](CCExtIdleNotificationV1* n) { onIdled((SIdleListener*)n->data()); });
+    notification->setResumed([this](CCExtIdleNotificationV1* n) { onResumed((SIdleListener*)n->data()); });
+
+    return notification;
+}
+
 void CHypridle::onInhibit(bool lock) {
     m_iInhibitLocks += lock ? 1 : -1;
 
     if (m_iInhibitLocks < 0) {
-        Debug::log(WARN, "BUG THIS: inhibit locks < 0: {}", m_iInhibitLocks);
+        Debug::log(WARN, "BUG THIS: inhibit locks < 0: {}", m_iInhibitLocks.load());
         m_iInhibitLocks = 0;
     }
 
@@ -310,28 +329,29 @@ void CHypridle::onInhibit(bool lock) {
             auto&       l = m_sWaylandIdleState.listeners[i];
             const auto& r = RULES[i];
 
+            if (r.afterLock || r.beforeLock)
+                continue;
+
             l.notification->sendDestroy();
 
-            if (*IGNOREWAYLANDINHIBIT || r.ignoreInhibit)
-                l.notification =
-                    makeShared<CCExtIdleNotificationV1>(m_sWaylandIdleState.notifier->sendGetInputIdleNotification(r.timeout * 1000 /* ms */, m_sWaylandState.seat->resource()));
-            else
-                l.notification =
-                    makeShared<CCExtIdleNotificationV1>(m_sWaylandIdleState.notifier->sendGetIdleNotification(r.timeout * 1000 /* ms */, m_sWaylandState.seat->resource()));
-
-            l.notification->setData(&m_sWaylandIdleState.listeners[i]);
-
-            l.notification->setIdled([this](CCExtIdleNotificationV1* n) { onIdled((CHypridle::SIdleListener*)n->data()); });
-            l.notification->setResumed([this](CCExtIdleNotificationV1* n) { onResumed((CHypridle::SIdleListener*)n->data()); });
+            l.notification = createIdleNotification(r.timeout * 1000 /* ms */, *IGNOREWAYLANDINHIBIT || r.ignoreInhibit, &m_sWaylandIdleState.listeners[i]);
         }
     }
 
-    Debug::log(LOG, "Inhibit locks: {}", m_iInhibitLocks);
+    Debug::log(LOG, "Inhibit locks: {}", m_iInhibitLocks.load());
 }
 
 void CHypridle::onLocked() {
     Debug::log(LOG, "Wayland session got locked");
     m_isLocked = true;
+
+    for (auto& l : m_sWaylandIdleState.listeners) {
+        if (l.afterLock && !l.onTimeout.empty()) {
+            Debug::log(LOG, "Running after_lock for rule {:x}", (uintptr_t)&l);
+            l.onTimeoutFired = true;
+            spawn(l.onTimeout);
+        }
+    }
 
     static const auto LOCKCMD = g_pConfigManager->getValue<Hyprlang::STRING>("general:on_lock_cmd");
     if (!std::string{*LOCKCMD}.empty())
@@ -345,12 +365,41 @@ void CHypridle::onUnlocked() {
     Debug::log(LOG, "Wayland session got unlocked");
     m_isLocked = false;
 
+    for (auto& l : m_sWaylandIdleState.listeners) {
+        if (l.afterLock && l.onTimeoutFired && !l.onRestore.empty()) {
+            Debug::log(LOG, "Running after_lock restore for rule {:x}", (uintptr_t)&l);
+            l.onTimeoutFired = false;
+            spawn(l.onRestore);
+        }
+    }
+
     if (m_inhibitSleepBehavior == SLEEP_INHIBIT_LOCK_NOTIFY)
         inhibitSleep();
 
     static const auto UNLOCKCMD = g_pConfigManager->getValue<Hyprlang::STRING>("general:on_unlock_cmd");
     if (!std::string{*UNLOCKCMD}.empty())
         spawn(*UNLOCKCMD);
+}
+
+void CHypridle::fireBeforeLockListeners(bool toSleep) {
+    for (auto& l : m_sWaylandIdleState.listeners) {
+        if (!l.beforeLock)
+            continue;
+
+        if (toSleep) {
+            if (!l.onTimeout.empty()) {
+                Debug::log(LOG, "Running before_lock for rule {:x}", (uintptr_t)&l);
+                l.onTimeoutFired = true;
+                spawn(l.onTimeout);
+            }
+        } else {
+            if (l.onTimeoutFired && !l.onRestore.empty()) {
+                Debug::log(LOG, "Running before_lock restore for rule {:x}", (uintptr_t)&l);
+                l.onTimeoutFired = false;
+                spawn(l.onRestore);
+            }
+        }
+    }
 }
 
 CHypridle::SDbusInhibitCookie CHypridle::getDbusInhibitCookie(uint32_t cookie) {
@@ -419,6 +468,12 @@ static void handleDbusSleep(sdbus::Message msg) {
 
     Debug::log(LOG, "Got PrepareForSleep from dbus with sleep {}", toSleep);
 
+    if (toSleep) {
+        g_pHypridle->fireBeforeLockListeners(true);
+    } else {
+        g_pHypridle->fireBeforeLockListeners(false);
+    }
+
     std::string cmd = toSleep ? *SLEEPCMD : *AFTERSLEEPCMD;
 
     if (!toSleep)
@@ -458,8 +513,8 @@ static void handleDbusBlockInhibitsPropertyChanged(sdbus::Message msg) {
 }
 
 static uint32_t handleDbusScreensaver(std::string app, std::string reason, uint32_t cookie, bool inhibit, const char* sender) {
-    std::string ownerID = sender;
-    bool cookieFound = false;
+    std::string ownerID     = sender;
+    bool        cookieFound = false;
 
     if (!inhibit) {
         Debug::log(TRACE, "Read uninhibit cookie: {}", cookie);
@@ -467,9 +522,9 @@ static uint32_t handleDbusScreensaver(std::string app, std::string reason, uint3
         if (COOKIE.cookie == 0) {
             Debug::log(WARN, "No cookie in uninhibit");
         } else {
-            app     = COOKIE.app;
-            reason  = COOKIE.reason;
-            ownerID = COOKIE.ownerID;
+            app         = COOKIE.app;
+            reason      = COOKIE.reason;
+            ownerID     = COOKIE.ownerID;
             cookieFound = true;
 
             if (!g_pHypridle->unregisterDbusInhibitCookie(COOKIE))
@@ -493,7 +548,10 @@ static uint32_t handleDbusScreensaver(std::string app, std::string reason, uint3
 
         g_pHypridle->registerDbusInhibitCookie(cookie);
 
-        return cookieID++;
+        uint32_t current = cookieID++;
+        if (cookieID == 0)
+            cookieID = 1337;
+        return current;
     }
 
     return 0;

--- a/src/core/Hypridle.hpp
+++ b/src/core/Hypridle.hpp
@@ -5,6 +5,7 @@
 #include <sdbus-c++/sdbus-c++.h>
 #include <hyprutils/os/FileDescriptor.hpp>
 #include <condition_variable>
+#include <atomic>
 
 #include "wayland.hpp"
 #include "ext-idle-notify-v1.hpp"
@@ -17,11 +18,13 @@ class CHypridle {
     CHypridle();
 
     struct SIdleListener {
-        SP<CCExtIdleNotificationV1> notification     = nullptr;
-        std::string                 onTimeout        = "";
-        std::string                 onRestore        = "";
-        bool                        ignoreInhibit    = false;
-        bool                        onTimeoutFired   = false;
+        SP<CCExtIdleNotificationV1> notification   = nullptr;
+        std::string                 onTimeout      = "";
+        std::string                 onRestore      = "";
+        bool                        ignoreInhibit  = false;
+        bool                        onTimeoutFired = false;
+        bool                        afterLock      = false;
+        bool                        beforeLock     = false;
     };
 
     struct SDbusInhibitCookie {
@@ -29,36 +32,40 @@ class CHypridle {
         std::string app, reason, ownerID;
     };
 
-    void               run();
+    void                        run();
 
-    void               onGlobal(void* data, struct wl_registry* registry, uint32_t name, const char* interface, uint32_t version);
-    void               onGlobalRemoved(void* data, struct wl_registry* registry, uint32_t name);
+    void                        onGlobal(void* data, struct wl_registry* registry, uint32_t name, const char* interface, uint32_t version);
+    void                        onGlobalRemoved(void* data, struct wl_registry* registry, uint32_t name);
 
-    void               onIdled(SIdleListener*);
-    void               onResumed(SIdleListener*);
+    void                        onIdled(SIdleListener*);
+    void                        onResumed(SIdleListener*);
 
-    void               onInhibit(bool lock);
+    void                        onInhibit(bool lock);
 
-    void               onLocked();
-    void               onUnlocked();
+    void                        onLocked();
+    void                        onUnlocked();
 
-    SDbusInhibitCookie getDbusInhibitCookie(uint32_t cookie);
-    void               registerDbusInhibitCookie(SDbusInhibitCookie& cookie);
-    bool               unregisterDbusInhibitCookie(const SDbusInhibitCookie& cookie);
-    size_t             unregisterDbusInhibitCookies(const std::string& ownerID);
+    SP<CCExtIdleNotificationV1> createIdleNotification(uint32_t timeoutMs, bool ignoreInhibit, SIdleListener* listener);
 
-    void               handleInhibitOnDbusSleep(bool toSleep);
-    void               inhibitSleep();
-    void               uninhibitSleep();
+    SDbusInhibitCookie          getDbusInhibitCookie(uint32_t cookie);
+    void                        registerDbusInhibitCookie(SDbusInhibitCookie& cookie);
+    bool                        unregisterDbusInhibitCookie(const SDbusInhibitCookie& cookie);
+    size_t                      unregisterDbusInhibitCookies(const std::string& ownerID);
+
+    void                        handleInhibitOnDbusSleep(bool toSleep);
+    void                        inhibitSleep();
+    void                        uninhibitSleep();
+
+    void                        fireBeforeLockListeners(bool toSleep);
 
   private:
-    void    setupDBUS();
-    void    enterEventLoop();
+    void                 setupDBUS();
+    void                 enterEventLoop();
 
-    bool    m_bTerminate    = false;
-    bool    isIdled         = false;
-    bool    m_isLocked      = false;
-    int64_t m_iInhibitLocks = 0;
+    std::atomic<bool>    m_bTerminate    = false;
+    std::atomic<bool>    isIdled         = false;
+    bool                 m_isLocked      = false;
+    std::atomic<int64_t> m_iInhibitLocks = 0;
 
     enum {
         SLEEP_INHIBIT_NONE,


### PR DESCRIPTION
## Summary
Add `after_lock` and `before_lock` per-listener trigger modes.
When set, `on-timeout` fires on Wayland lock/sleep events instead of idle timeouts.
## Problem

Current options `general:on_lock_cmd` and `general:before_sleep_cmd` only allow a single global command (chained via `&&`).
This prevents per-listener behavior and forces unrelated actions into one command chain.

Common use cases that need separation:
* Turn off display on lock, but not on suspend
* Run cleanup (e.g. VPN disconnect, backup) only before suspend
* Avoid mixing unrelated actions in a single global hook
## Solution
Two new per-listener trigger modes:
```ini
listener {
    after_lock = true
    on-timeout = hyprctl dispatch dpms off
    on-resume = hyprctl dispatch dpms on
}
```

```ini
listener {
    before_lock = true
    on-timeout = vpn disconnect && ~/scripts/backup.sh
    on-resume = vpn connect work
}
```
### Behavior
#### `after_lock`
* `on-timeout` → Wayland session locked (e.g. `loginctl lock-session`, `hyprlock`)
* `on-resume` → Wayland session unlocked
#### `before_lock`
* `on-timeout` → `PrepareForSleep(true)` DBus signal (system preparing to suspend)
* `on-resume` → `PrepareForSleep(false)` DBus signal (system resumed)

### Constraints
* `after_lock` and `before_lock` are mutually exclusive
* Both are mutually exclusive with `timeout`
* Invalid combinations produce a config error

## Examples
**Dim on idle + DPMS on lock + VPN on suspend:**
```ini
# Dim screen after 5 minutes idle
listener {
    timeout = 300
    on-timeout = brightnessctl set 30%
    on-resume = brightnessctl set 100%
}

# Turn off display immediately on lock
listener {
    after_lock = true
    on-timeout = hyprctl dispatch dpms off
    on-resume = hyprctl dispatch dpms on
}

# Disconnect VPN on suspend, reconnect on wake
listener {
    before_lock = true
    on-timeout = vpn disconnect
    on-resume = vpn connect work
}
```
## Changed

* Lock-based listeners do not create Wayland idle notifications (reduced overhead) (based on Issue #189)
* `onInhibit` logic skips lock-based listeners (no idle dependency)

## Fixed

* `m_iInhibitLocks`, `m_bTerminate`, and `isIdled` are now `std::atomic<>` for thread safety
* Cookie IDs now wrap to `1337` instead of `0` to avoid conflicts
* Event loop `pollfd` handling now terminates gracefully via mutex signaling instead of `exit(1)`
* Fixed capture of `threadPollfdsCount` in the polling lambda
* Fixed `cookieFound` initialization in `handleDbusScreensaver`
