### PR TITLE
config: update dpms commands to lua syntax

### DIFF
--- a/assets/example.conf
+++ b/assets/example.conf
@@ -2,9 +2,9 @@
 # for more configuration options, refer https://wiki.hyprland.org/Hypr-Ecosystem/hypridle
 
 general {
-    lock_cmd = pidof hyprlock || hyprlock       # avoid starting multiple hyprlock instances.
-    before_sleep_cmd = loginctl lock-session    # lock before suspend.
-    after_sleep_cmd = hyprctl dispatch dpms on  # to avoid having to press a key twice to turn on the display.
+    lock_cmd = pidof hyprlock || hyprlock                             # avoid starting multiple hyprlock instances.
+    before_sleep_cmd = loginctl lock-session                          # lock before suspend.
+    after_sleep_cmd = hyprctl dispatch 'hl.dsp.dpms({action = "on"})' # turn on screen w/o key press after resume.
 }
 
 listener {
@@ -26,9 +26,9 @@ listener {
 }
 
 listener {
-    timeout = 330                                 # 5.5min.
-    on-timeout = hyprctl dispatch dpms off        # screen off when timeout has passed.
-    on-resume = hyprctl dispatch dpms on          # screen on when activity is detected after timeout has fired.
+    timeout = 330                                                 # 5.5min.
+    on-timeout = hyprctl dispatch 'hl.dsp.dpms({action = "off"})' # screen off when timeout has passed.
+    on-resume = hyprctl dispatch 'hl.dsp.dpms({action = "on"})'   # screen on when activity is detected.
 }
 
 listener {


### PR DESCRIPTION
```
$ hyprctl dispatch dpms off
error: [string "return hl.dispatch(dpms off)"]:1: ')' expected near
'off'

 → Note: dispatch in lua is a shorthand for hl.dispatch(...), your syntax might need to be updated.
```